### PR TITLE
開発用の画面を作成

### DIFF
--- a/spotter.xcodeproj/project.pbxproj
+++ b/spotter.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		BEA4CBB61F7B53410066BF44 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEA4CBB41F7B53410066BF44 /* Alamofire.framework */; };
 		BEA4CBB71F7B53410066BF44 /* SwiftyJSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEA4CBB51F7B53410066BF44 /* SwiftyJSON.framework */; };
 		BEA4CBBA1F7B8DB10066BF44 /* RoundRectButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CBB91F7B8DB10066BF44 /* RoundRectButton.swift */; };
+		BEA4CBBC1F7BA7400066BF44 /* login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BEA4CBBB1F7BA7400066BF44 /* login.storyboard */; };
+		BEA4CBBE1F7BA82C0066BF44 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CBBD1F7BA82C0066BF44 /* LoginViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,6 +55,8 @@
 		BEA4CBB41F7B53410066BF44 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		BEA4CBB51F7B53410066BF44 /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
 		BEA4CBB91F7B8DB10066BF44 /* RoundRectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundRectButton.swift; sourceTree = "<group>"; };
+		BEA4CBBB1F7BA7400066BF44 /* login.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = login.storyboard; sourceTree = "<group>"; };
+		BEA4CBBD1F7BA82C0066BF44 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -148,6 +152,7 @@
 		BEA4CBA61F7A21BA0066BF44 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				BEA4CBBD1F7BA82C0066BF44 /* LoginViewController.swift */,
 				BEA4CBB11F7A22EA0066BF44 /* ViewController.swift */,
 			);
 			path = Controllers;
@@ -187,6 +192,7 @@
 			children = (
 				BEA4CBAD1F7A21C50066BF44 /* LaunchScreen.storyboard */,
 				BEA4CBAE1F7A21C50066BF44 /* Main.storyboard */,
+				BEA4CBBB1F7BA7400066BF44 /* login.storyboard */,
 			);
 			path = Storyboards;
 			sourceTree = "<group>";
@@ -308,6 +314,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BEA4CBBC1F7BA7400066BF44 /* login.storyboard in Resources */,
 				BEA4CBAF1F7A226C0066BF44 /* LaunchScreen.storyboard in Resources */,
 				BEA4CBB01F7A226C0066BF44 /* Main.storyboard in Resources */,
 				BEA4CB7F1F7A207B0066BF44 /* Assets.xcassets in Resources */,
@@ -355,6 +362,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BEA4CBBE1F7BA82C0066BF44 /* LoginViewController.swift in Sources */,
 				BEA4CBB21F7A22EA0066BF44 /* ViewController.swift in Sources */,
 				BEA4CBBA1F7B8DB10066BF44 /* RoundRectButton.swift in Sources */,
 				BEA4CB781F7A207B0066BF44 /* AppDelegate.swift in Sources */,

--- a/spotter/Classes/Controllers/LoginViewController.swift
+++ b/spotter/Classes/Controllers/LoginViewController.swift
@@ -1,0 +1,24 @@
+//
+//  LoginViewController.swift
+//  spotter
+//
+//  Created by komei.nomura on 2017/09/27.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import UIKit
+
+class LoginViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+
+}

--- a/spotter/Storyboards/Main.storyboard
+++ b/spotter/Storyboards/Main.storyboard
@@ -17,92 +17,30 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ユーザID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4WU-5Z-j5I">
-                                <rect key="frame" x="41" y="289" width="76" height="23"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="パスワード" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="E04-4K-oR1">
-                                <rect key="frame" x="41" y="398" width="97" height="23"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="ej1-ko-ozA">
-                                <rect key="frame" x="41" y="429" width="293" height="30"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="unp-yA-Sbu">
-                                <rect key="frame" x="41" y="320" width="293" height="30"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Spotter" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="W2R-Gh-OYz">
-                                <rect key="frame" x="109" y="90" width="157" height="60"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="50"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="stt-bD-gv5" customClass="RoundRectButton" customModule="spotter" customModuleProvider="target">
-                                <rect key="frame" x="41" y="543" width="293" height="42"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
-                                <state key="normal" title="ログイン"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="buttonColor">
-                                        <color key="value" red="0.072392590343952179" green="0.823314368724823" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
-                                        <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                        <real key="value" value="8"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="SCE-Qh-Ht9">
+                                <rect key="frame" x="133" y="64" width="108" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="ログイン画面へ"/>
+                                <connections>
+                                    <segue destination="61g-AH-GGk" kind="show" id="oG6-GL-OpI"/>
+                                </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="エラーメッセージ用" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="d4y-x0-yl1">
-                                <rect key="frame" x="41" y="222" width="293" height="40"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <constraints>
-                            <constraint firstItem="unp-yA-Sbu" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="41" id="1RG-RK-ipp"/>
-                            <constraint firstItem="ej1-ko-ozA" firstAttribute="top" secondItem="E04-4K-oR1" secondAttribute="bottom" constant="8" id="71f-vY-Hd4"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="bottom" secondItem="stt-bD-gv5" secondAttribute="bottom" constant="82" id="7YU-pn-5C0"/>
-                            <constraint firstItem="4WU-5Z-j5I" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="41" id="Bxu-IS-6Co"/>
-                            <constraint firstItem="E04-4K-oR1" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="41" id="DQW-0z-fIg"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="d4y-x0-yl1" secondAttribute="trailing" constant="41" id="EBL-Ws-9s3"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="unp-yA-Sbu" secondAttribute="trailing" constant="41" id="ECc-wS-cyJ"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="ej1-ko-ozA" secondAttribute="trailing" constant="41" id="GNR-Nt-Z18"/>
-                            <constraint firstItem="4WU-5Z-j5I" firstAttribute="top" secondItem="W2R-Gh-OYz" secondAttribute="bottom" constant="139" id="J6f-5r-58I"/>
-                            <constraint firstItem="d4y-x0-yl1" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="41" id="JOm-NL-CYH"/>
-                            <constraint firstItem="ej1-ko-ozA" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="41" id="JUI-rD-7V8"/>
-                            <constraint firstItem="d4y-x0-yl1" firstAttribute="top" secondItem="W2R-Gh-OYz" secondAttribute="bottom" constant="72" id="XJX-et-bIF"/>
-                            <constraint firstItem="W2R-Gh-OYz" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="70" id="YCo-Iu-KaC"/>
-                            <constraint firstItem="ej1-ko-ozA" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="bkw-J8-x2R"/>
-                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="stt-bD-gv5" secondAttribute="trailing" constant="41" id="d3T-mk-0CM"/>
-                            <constraint firstItem="d4y-x0-yl1" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="dAY-Gh-Jes"/>
-                            <constraint firstItem="unp-yA-Sbu" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="eeo-bz-dqM"/>
-                            <constraint firstItem="4WU-5Z-j5I" firstAttribute="top" secondItem="d4y-x0-yl1" secondAttribute="bottom" constant="27" id="lPy-Iz-NCf"/>
-                            <constraint firstItem="E04-4K-oR1" firstAttribute="top" secondItem="unp-yA-Sbu" secondAttribute="bottom" constant="48" id="n2V-7X-Xrf"/>
-                            <constraint firstItem="stt-bD-gv5" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="pvW-Oa-eAi"/>
-                            <constraint firstItem="ej1-ko-ozA" firstAttribute="top" secondItem="E04-4K-oR1" secondAttribute="bottom" constant="8" id="qgR-Cv-oTW"/>
-                            <constraint firstItem="unp-yA-Sbu" firstAttribute="top" secondItem="4WU-5Z-j5I" secondAttribute="bottom" constant="8" id="sBV-vy-pnP"/>
-                            <constraint firstItem="stt-bD-gv5" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="41" id="vfQ-lz-weF"/>
-                            <constraint firstItem="W2R-Gh-OYz" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="wHk-yh-Lcf"/>
-                        </constraints>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="32.799999999999997" y="32.833583208395808"/>
+        </scene>
+        <!--login-->
+        <scene sceneID="12G-ES-wIb">
+            <objects>
+                <viewControllerPlaceholder storyboardName="login" id="61g-AH-GGk" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="V3X-UH-97X" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="846" y="-257"/>
         </scene>
     </scenes>
 </document>

--- a/spotter/Storyboards/login.storyboard
+++ b/spotter/Storyboards/login.storyboard
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="CI2-0d-gYl">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--login-->
+        <scene sceneID="cAF-zp-aGU">
+            <objects>
+                <viewController title="login" id="CI2-0d-gYl" customClass="LoginViewController" customModule="spotter" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="GMM-kE-eEf">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ユーザID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qUP-Sk-rqJ">
+                                <rect key="frame" x="41" y="289" width="76" height="23"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="パスワード" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QAo-V7-tQs">
+                                <rect key="frame" x="41" y="398" width="97" height="23"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="RUg-zJ-Kry">
+                                <rect key="frame" x="41" y="429" width="293" height="30"/>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="h5G-kv-yXS">
+                                <rect key="frame" x="41" y="320" width="293" height="30"/>
+                                <nil key="textColor"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Spotter" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NKN-mt-CGh">
+                                <rect key="frame" x="109" y="90" width="157" height="60"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="50"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="y14-oT-5bz" customClass="RoundRectButton" customModule="spotter" customModuleProvider="target">
+                                <rect key="frame" x="41" y="543" width="293" height="42"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="25"/>
+                                <state key="normal" title="ログイン"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="buttonColor">
+                                        <color key="value" red="0.072392590339999993" green="0.82331436869999997" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                        <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="8"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </button>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="エラーメッセージ用" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YFK-o9-XY4">
+                                <rect key="frame" x="41" y="222" width="293" height="40"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="NKN-mt-CGh" firstAttribute="top" secondItem="mea-IL-sp2" secondAttribute="top" constant="70" id="2bY-E1-Tgk"/>
+                            <constraint firstItem="h5G-kv-yXS" firstAttribute="top" secondItem="qUP-Sk-rqJ" secondAttribute="bottom" constant="8" id="6K0-3C-Yyj"/>
+                            <constraint firstItem="NKN-mt-CGh" firstAttribute="centerX" secondItem="GMM-kE-eEf" secondAttribute="centerX" id="7e2-w8-oDS"/>
+                            <constraint firstItem="mea-IL-sp2" firstAttribute="trailing" secondItem="RUg-zJ-Kry" secondAttribute="trailing" constant="41" id="8Kc-IP-yLZ"/>
+                            <constraint firstItem="QAo-V7-tQs" firstAttribute="top" secondItem="h5G-kv-yXS" secondAttribute="bottom" constant="48" id="8Kx-0N-JI5"/>
+                            <constraint firstItem="RUg-zJ-Kry" firstAttribute="top" secondItem="QAo-V7-tQs" secondAttribute="bottom" constant="8" id="Ldq-lB-bCa"/>
+                            <constraint firstItem="mea-IL-sp2" firstAttribute="trailing" secondItem="y14-oT-5bz" secondAttribute="trailing" constant="41" id="MMs-fy-chx"/>
+                            <constraint firstItem="RUg-zJ-Kry" firstAttribute="top" secondItem="QAo-V7-tQs" secondAttribute="bottom" constant="8" id="RMR-GY-kJ1"/>
+                            <constraint firstItem="mea-IL-sp2" firstAttribute="trailing" secondItem="YFK-o9-XY4" secondAttribute="trailing" constant="41" id="RMR-dT-jzw"/>
+                            <constraint firstItem="QAo-V7-tQs" firstAttribute="leading" secondItem="mea-IL-sp2" secondAttribute="leading" constant="41" id="Tf9-TC-drG"/>
+                            <constraint firstItem="h5G-kv-yXS" firstAttribute="leading" secondItem="mea-IL-sp2" secondAttribute="leading" constant="41" id="UGO-Ti-X6f"/>
+                            <constraint firstItem="RUg-zJ-Kry" firstAttribute="centerX" secondItem="GMM-kE-eEf" secondAttribute="centerX" id="V53-g3-tut"/>
+                            <constraint firstItem="YFK-o9-XY4" firstAttribute="centerX" secondItem="GMM-kE-eEf" secondAttribute="centerX" id="VNU-n8-PWT"/>
+                            <constraint firstItem="mea-IL-sp2" firstAttribute="bottom" secondItem="y14-oT-5bz" secondAttribute="bottom" constant="82" id="hHy-tD-UGa"/>
+                            <constraint firstItem="RUg-zJ-Kry" firstAttribute="leading" secondItem="mea-IL-sp2" secondAttribute="leading" constant="41" id="hhw-RH-Ilk"/>
+                            <constraint firstItem="y14-oT-5bz" firstAttribute="leading" secondItem="mea-IL-sp2" secondAttribute="leading" constant="41" id="j7k-cf-tVy"/>
+                            <constraint firstItem="h5G-kv-yXS" firstAttribute="centerX" secondItem="GMM-kE-eEf" secondAttribute="centerX" id="kC7-FC-6At"/>
+                            <constraint firstItem="y14-oT-5bz" firstAttribute="centerX" secondItem="GMM-kE-eEf" secondAttribute="centerX" id="l2H-Ho-jB3"/>
+                            <constraint firstItem="qUP-Sk-rqJ" firstAttribute="top" secondItem="YFK-o9-XY4" secondAttribute="bottom" constant="27" id="l65-xs-Ras"/>
+                            <constraint firstItem="qUP-Sk-rqJ" firstAttribute="leading" secondItem="mea-IL-sp2" secondAttribute="leading" constant="41" id="lxs-hl-vab"/>
+                            <constraint firstItem="YFK-o9-XY4" firstAttribute="leading" secondItem="mea-IL-sp2" secondAttribute="leading" constant="41" id="n54-a8-1L2"/>
+                            <constraint firstItem="YFK-o9-XY4" firstAttribute="top" secondItem="NKN-mt-CGh" secondAttribute="bottom" constant="72" id="tgU-hO-HkT"/>
+                            <constraint firstItem="mea-IL-sp2" firstAttribute="trailing" secondItem="h5G-kv-yXS" secondAttribute="trailing" constant="41" id="ynJ-YF-K0q"/>
+                            <constraint firstItem="qUP-Sk-rqJ" firstAttribute="top" secondItem="NKN-mt-CGh" secondAttribute="bottom" constant="139" id="zfJ-3Z-sbI"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="mea-IL-sp2"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="6cC-D1-HvC" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="32.799999999999997" y="32.833583208395808"/>
+        </scene>
+    </scenes>
+</document>


### PR DESCRIPTION
### 何を解決するのか

- 開発用の初期画面を実装
    - 画面が増えてくると、デバッグ時に画面遷移が大変になりそうなので画面遷移をスキップできる初期画面を作った
    - この画面は不要になったときに削除する予定
- ログイン画面を`login.storyboard`に分離

### 詳細

- 開発用の初期画面
    - ストーリーボード：`main.storyboad`
    - コントローラ：`ViewController`
    - 「ログイン画面へ」ボタンを押すとログイン画面に遷移
![image](https://user-images.githubusercontent.com/28612605/30947939-93e06d62-a447-11e7-8ff4-9489bb7e69c9.png)

- ログイン画面
    - ストーリーボード：`login.storyboard`
    - コントローラ：`LoginViewController`
    - https://github.com/pepabo-mobile-app-training/spotter/pull/9 で実装した内容をmainから分離

### レビュアー

@Fendo181 @Asuforce 

### 期限

速でお願いします！
