### PR TITLE
Tweet投稿画面を実装

### DIFF
--- a/spotter.xcodeproj/project.pbxproj
+++ b/spotter.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		BEA4CBBA1F7B8DB10066BF44 /* RoundRectButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CBB91F7B8DB10066BF44 /* RoundRectButton.swift */; };
 		BEA4CBBC1F7BA7400066BF44 /* login.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BEA4CBBB1F7BA7400066BF44 /* login.storyboard */; };
 		BEA4CBBE1F7BA82C0066BF44 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CBBD1F7BA82C0066BF44 /* LoginViewController.swift */; };
+		BEA4CBC01F7CC7C10066BF44 /* tweet.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BEA4CBBF1F7CC7C10066BF44 /* tweet.storyboard */; };
+		BEA4CBC21F7CC7E00066BF44 /* TweetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CBC11F7CC7E00066BF44 /* TweetViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -57,6 +59,8 @@
 		BEA4CBB91F7B8DB10066BF44 /* RoundRectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoundRectButton.swift; sourceTree = "<group>"; };
 		BEA4CBBB1F7BA7400066BF44 /* login.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = login.storyboard; sourceTree = "<group>"; };
 		BEA4CBBD1F7BA82C0066BF44 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		BEA4CBBF1F7CC7C10066BF44 /* tweet.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = tweet.storyboard; sourceTree = "<group>"; };
+		BEA4CBC11F7CC7E00066BF44 /* TweetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -152,6 +156,7 @@
 		BEA4CBA61F7A21BA0066BF44 /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				BEA4CBC11F7CC7E00066BF44 /* TweetViewController.swift */,
 				BEA4CBBD1F7BA82C0066BF44 /* LoginViewController.swift */,
 				BEA4CBB11F7A22EA0066BF44 /* ViewController.swift */,
 			);
@@ -190,6 +195,7 @@
 		BEA4CBAC1F7A21C50066BF44 /* Storyboards */ = {
 			isa = PBXGroup;
 			children = (
+				BEA4CBBF1F7CC7C10066BF44 /* tweet.storyboard */,
 				BEA4CBAD1F7A21C50066BF44 /* LaunchScreen.storyboard */,
 				BEA4CBAE1F7A21C50066BF44 /* Main.storyboard */,
 				BEA4CBBB1F7BA7400066BF44 /* login.storyboard */,
@@ -318,6 +324,7 @@
 				BEA4CBAF1F7A226C0066BF44 /* LaunchScreen.storyboard in Resources */,
 				BEA4CBB01F7A226C0066BF44 /* Main.storyboard in Resources */,
 				BEA4CB7F1F7A207B0066BF44 /* Assets.xcassets in Resources */,
+				BEA4CBC01F7CC7C10066BF44 /* tweet.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -364,6 +371,7 @@
 			files = (
 				BEA4CBBE1F7BA82C0066BF44 /* LoginViewController.swift in Sources */,
 				BEA4CBB21F7A22EA0066BF44 /* ViewController.swift in Sources */,
+				BEA4CBC21F7CC7E00066BF44 /* TweetViewController.swift in Sources */,
 				BEA4CBBA1F7B8DB10066BF44 /* RoundRectButton.swift in Sources */,
 				BEA4CB781F7A207B0066BF44 /* AppDelegate.swift in Sources */,
 			);

--- a/spotter.xcodeproj/project.pbxproj
+++ b/spotter.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		BEA4CBBE1F7BA82C0066BF44 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CBBD1F7BA82C0066BF44 /* LoginViewController.swift */; };
 		BEA4CBC01F7CC7C10066BF44 /* tweet.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BEA4CBBF1F7CC7C10066BF44 /* tweet.storyboard */; };
 		BEA4CBC21F7CC7E00066BF44 /* TweetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CBC11F7CC7E00066BF44 /* TweetViewController.swift */; };
+		BEA4CBC41F7CD0000066BF44 /* TweetTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CBC31F7CD0000066BF44 /* TweetTextView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -61,6 +62,7 @@
 		BEA4CBBD1F7BA82C0066BF44 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		BEA4CBBF1F7CC7C10066BF44 /* tweet.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = tweet.storyboard; sourceTree = "<group>"; };
 		BEA4CBC11F7CC7E00066BF44 /* TweetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetViewController.swift; sourceTree = "<group>"; };
+		BEA4CBC31F7CD0000066BF44 /* TweetTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetTextView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -188,6 +190,7 @@
 			isa = PBXGroup;
 			children = (
 				BEA4CBB91F7B8DB10066BF44 /* RoundRectButton.swift */,
+				BEA4CBC31F7CD0000066BF44 /* TweetTextView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -370,6 +373,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BEA4CBBE1F7BA82C0066BF44 /* LoginViewController.swift in Sources */,
+				BEA4CBC41F7CD0000066BF44 /* TweetTextView.swift in Sources */,
 				BEA4CBB21F7A22EA0066BF44 /* ViewController.swift in Sources */,
 				BEA4CBC21F7CC7E00066BF44 /* TweetViewController.swift in Sources */,
 				BEA4CBBA1F7B8DB10066BF44 /* RoundRectButton.swift in Sources */,

--- a/spotter/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/spotter/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/spotter/Classes/Controllers/TweetViewController.swift
+++ b/spotter/Classes/Controllers/TweetViewController.swift
@@ -1,0 +1,35 @@
+//
+//  TweetViewController.swift
+//  spotter
+//
+//  Created by komei.nomura on 2017/09/28.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import UIKit
+
+class TweetViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+        // Dispose of any resources that can be recreated.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destinationViewController.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/spotter/Classes/Views/TweetTextView.swift
+++ b/spotter/Classes/Views/TweetTextView.swift
@@ -1,0 +1,32 @@
+//
+//  TweetTextView.swift
+//  spotter
+//
+//  Created by komei.nomura on 2017/09/28.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import UIKit
+
+@IBDesignable
+class TweetTextView: UITextView {
+
+    @IBInspectable var borderWidth : CGFloat = 0 {
+        didSet {
+            layer.borderWidth = borderWidth
+        }
+    }
+    
+    @IBInspectable var borderColor : UIColor = UIColor.clear {
+        didSet {
+            layer.borderColor = borderColor.cgColor
+        }
+    }
+    
+    @IBInspectable var cornerRadius : CGFloat = 0 {
+        didSet {
+            layer.cornerRadius = cornerRadius
+        }
+    }
+
+}

--- a/spotter/Storyboards/Main.storyboard
+++ b/spotter/Storyboards/Main.storyboard
@@ -25,6 +25,14 @@
                                     <segue destination="61g-AH-GGk" kind="show" id="oG6-GL-OpI"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fXi-24-Ago">
+                                <rect key="frame" x="143" y="261" width="88" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Tweet画面へ"/>
+                                <connections>
+                                    <segue destination="MuX-pV-MtE" kind="show" id="PhD-uO-JQL"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
@@ -41,6 +49,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="V3X-UH-97X" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="846" y="-257"/>
+        </scene>
+        <!--tweet-->
+        <scene sceneID="12Q-cb-ExV">
+            <objects>
+                <viewControllerPlaceholder storyboardName="tweet" id="MuX-pV-MtE" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Xw8-z0-idp" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="890" y="96"/>
         </scene>
     </scenes>
 </document>

--- a/spotter/Storyboards/tweet.storyboard
+++ b/spotter/Storyboards/tweet.storyboard
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hKa-NW-TGy">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Tweet View Controller-->
+        <scene sceneID="VgP-Go-7q5">
+            <objects>
+                <viewController id="hKa-NW-TGy" customClass="TweetViewController" customModule="spotter" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="PpP-OP-dT4">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <viewLayoutGuide key="safeArea" id="QSj-Bs-TFw"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3Ah-fN-XFe" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-137" y="99"/>
+        </scene>
+    </scenes>
+</document>

--- a/spotter/Storyboards/tweet.storyboard
+++ b/spotter/Storyboards/tweet.storyboard
@@ -5,6 +5,7 @@
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,15 +18,58 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="あいうえお" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="d3T-7r-DrF">
-                                <rect key="frame" x="67" y="88" width="240" height="128"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4eU-rF-geh" customClass="RoundRectButton" customModule="spotter" customModuleProvider="target">
+                                <rect key="frame" x="243" y="319" width="112" height="48"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="112" id="Qlf-Y6-Jfh"/>
+                                    <constraint firstAttribute="height" constant="48" id="olP-0B-WL2"/>
+                                    <constraint firstAttribute="width" secondItem="4eU-rF-geh" secondAttribute="height" multiplier="7:3" id="qcq-Fv-Sq2"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="15"/>
+                                <state key="normal" title="今の気持ち"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="20"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="buttonColor">
+                                        <color key="value" red="0.072392590339999993" green="0.82331436869999997" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                        <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </button>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="d3T-7r-DrF" customClass="TweetTextView" customModule="spotter" customModuleProvider="target">
+                                <rect key="frame" x="20" y="134" width="335" height="160"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="d3T-7r-DrF" secondAttribute="height" multiplier="67:32" id="DP8-LF-lb8"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="2"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="6"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
                             </textView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="QSj-Bs-TFw" firstAttribute="trailing" secondItem="d3T-7r-DrF" secondAttribute="trailing" constant="20" id="QrM-0u-ibP"/>
+                            <constraint firstItem="d3T-7r-DrF" firstAttribute="top" secondItem="QSj-Bs-TFw" secondAttribute="top" constant="70" id="Qvc-x3-FAo"/>
+                            <constraint firstItem="d3T-7r-DrF" firstAttribute="centerX" secondItem="PpP-OP-dT4" secondAttribute="centerX" id="X4c-Y2-xko"/>
+                            <constraint firstItem="d3T-7r-DrF" firstAttribute="leading" secondItem="QSj-Bs-TFw" secondAttribute="leading" constant="20" id="f0n-Ac-pxb"/>
+                            <constraint firstItem="4eU-rF-geh" firstAttribute="top" secondItem="d3T-7r-DrF" secondAttribute="bottom" constant="25" id="g1f-iQ-cWP"/>
+                            <constraint firstItem="4eU-rF-geh" firstAttribute="top" secondItem="d3T-7r-DrF" secondAttribute="bottom" constant="25" id="uVQ-Xg-gF2"/>
+                            <constraint firstItem="QSj-Bs-TFw" firstAttribute="trailing" secondItem="4eU-rF-geh" secondAttribute="trailing" constant="20" id="zwf-rh-ukn"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="QSj-Bs-TFw"/>
                     </view>
                     <navigationItem key="navigationItem" id="u8K-Bh-q5L">

--- a/spotter/Storyboards/tweet.storyboard
+++ b/spotter/Storyboards/tweet.storyboard
@@ -73,13 +73,7 @@
                         <viewLayoutGuide key="safeArea" id="QSj-Bs-TFw"/>
                     </view>
                     <navigationItem key="navigationItem" id="u8K-Bh-q5L">
-                        <barButtonItem key="rightBarButtonItem" style="plain" id="h6N-2q-ZVA">
-                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="ldI-WZ-VTA">
-                                <rect key="frame" x="318" y="7" width="41" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Home"/>
-                            </button>
-                        </barButtonItem>
+                        <barButtonItem key="rightBarButtonItem" title="Home" id="Jm5-jk-KUb"/>
                     </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3Ah-fN-XFe" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/spotter/Storyboards/tweet.storyboard
+++ b/spotter/Storyboards/tweet.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="hKa-NW-TGy">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="FNh-9P-6PZ">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -16,13 +16,49 @@
                     <view key="view" contentMode="scaleToFill" id="PpP-OP-dT4">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" text="あいうえお" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="d3T-7r-DrF">
+                                <rect key="frame" x="67" y="88" width="240" height="128"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                        </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <viewLayoutGuide key="safeArea" id="QSj-Bs-TFw"/>
                     </view>
+                    <navigationItem key="navigationItem" id="u8K-Bh-q5L">
+                        <barButtonItem key="rightBarButtonItem" style="plain" id="h6N-2q-ZVA">
+                            <button key="customView" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="ldI-WZ-VTA">
+                                <rect key="frame" x="318" y="7" width="41" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Home"/>
+                            </button>
+                        </barButtonItem>
+                    </navigationItem>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3Ah-fN-XFe" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-137" y="99"/>
+            <point key="canvasLocation" x="200.80000000000001" y="98.50074962518741"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="oC2-gZ-4aL">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="FNh-9P-6PZ" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="mrN-g4-waU">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="hKa-NW-TGy" kind="relationship" relationship="rootViewController" id="dbE-BO-gjR"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="XL9-Jv-Y5i" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-649" y="99"/>
         </scene>
     </scenes>
 </document>


### PR DESCRIPTION
### 何を解決するのか

-  Tweet投稿画面を実装
    - [ペーパープロトタイプ](https://github.com/pepabo-mobile-app-training/spotter/issues/1#issuecomment-332755789)をもとに作成



### 詳細

Tweet投稿画面

![image](https://user-images.githubusercontent.com/28612605/30956869-833381a8-a473-11e7-805c-937f0ed4ac92.png)

- コントローラ：`TweetViewController.swift`
- ストーリーボード：`tweet.storyboard`
    - navigation barを使って後の遷移を管理していきたいと思います。
- カスタムビュー
    - `TweetTextView.swift`
        - Tweet投稿用のテキストフィールドのカスタムビュー
    - `RoundRectButton.swift`
        - 次のページに遷移するボタンのカスタムビュー

### レビューポイント

- 画面の構成

### レビュアー

@Fendo181 @Asuforce 

### 期限

速でお願いします！
