### PR TITLE
ツイート確認画面の作成

### DIFF
--- a/spotter.xcodeproj/project.pbxproj
+++ b/spotter.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		BEA4CBC41F7CD0000066BF44 /* TweetTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CBC31F7CD0000066BF44 /* TweetTextView.swift */; };
 		BEA4CBC81F7CFB920066BF44 /* SelectMusic.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BEA4CBC71F7CFB920066BF44 /* SelectMusic.storyboard */; };
 		BEA4CBCC1F7CFC1C0066BF44 /* ConfirmTweet.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = BEA4CBCB1F7CFC1C0066BF44 /* ConfirmTweet.storyboard */; };
+		BEC8E0F71F83546600AD1806 /* confirmTweetViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8E0F61F83546600AD1806 /* confirmTweetViewUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -69,6 +70,7 @@
 		BEA4CBC31F7CD0000066BF44 /* TweetTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TweetTextView.swift; sourceTree = "<group>"; };
 		BEA4CBC71F7CFB920066BF44 /* SelectMusic.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = SelectMusic.storyboard; sourceTree = "<group>"; };
 		BEA4CBCB1F7CFC1C0066BF44 /* ConfirmTweet.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ConfirmTweet.storyboard; sourceTree = "<group>"; };
+		BEC8E0F61F83546600AD1806 /* confirmTweetViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = confirmTweetViewUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -143,6 +145,7 @@
 		BEA4CB961F7A207B0066BF44 /* spotterUITests */ = {
 			isa = PBXGroup;
 			children = (
+				BEC8E0F61F83546600AD1806 /* confirmTweetViewUITests.swift */,
 				BE0495AD1F823CA0000D4630 /* tweetViewUITests.swift */,
 				BEA4CB971F7A207B0066BF44 /* spotterUITests.swift */,
 				BEA4CB991F7A207B0066BF44 /* Info.plist */,
@@ -404,6 +407,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BEC8E0F71F83546600AD1806 /* confirmTweetViewUITests.swift in Sources */,
 				BE0495AE1F823CA0000D4630 /* tweetViewUITests.swift in Sources */,
 				BEA4CB981F7A207B0066BF44 /* spotterUITests.swift in Sources */,
 			);

--- a/spotter/Storyboards/ConfirmTweet.storyboard
+++ b/spotter/Storyboards/ConfirmTweet.storyboard
@@ -20,7 +20,7 @@
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="793-5d-Edp" customClass="TweetTextView" customModule="spotter" customModuleProvider="target">
                                 <rect key="frame" x="20" y="101" width="335" height="208"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <accessibility key="accessibilityConfiguration" identifier="tweetTextField"/>
+                                <accessibility key="accessibilityConfiguration" identifier="confirmTweetTextField"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="208" id="F7v-Kg-clZ"/>
                                 </constraints>

--- a/spotter/Storyboards/ConfirmTweet.storyboard
+++ b/spotter/Storyboards/ConfirmTweet.storyboard
@@ -17,21 +17,66 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Tweet確認画面" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="N8d-Ab-y2L">
-                                <rect key="frame" x="129" y="323" width="116" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="793-5d-Edp" customClass="TweetTextView" customModule="spotter" customModuleProvider="target">
+                                <rect key="frame" x="20" y="101" width="335" height="208"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <accessibility key="accessibilityConfiguration" identifier="tweetTextField"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="208" id="F7v-Kg-clZ"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="2"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="6"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wG3-Mx-HDm" customClass="RoundRectButton" customModule="spotter" customModuleProvider="target">
+                                <rect key="frame" x="219" y="368" width="136" height="56"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="136" id="63f-GL-dYL"/>
+                                    <constraint firstAttribute="height" constant="56" id="AMP-CN-OtY"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="19"/>
+                                <state key="normal" title="エモート"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="buttonColor">
+                                        <color key="value" red="0.072392590339999993" green="0.82331436869999997" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="textColor">
+                                        <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="20"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="793-5d-Edp" firstAttribute="leading" secondItem="hx8-uq-IDW" secondAttribute="leading" constant="20" id="G46-Cf-E4i"/>
+                            <constraint firstItem="793-5d-Edp" firstAttribute="top" secondItem="hx8-uq-IDW" secondAttribute="top" constant="37" id="GKr-16-MMe"/>
+                            <constraint firstItem="hx8-uq-IDW" firstAttribute="trailing" secondItem="wG3-Mx-HDm" secondAttribute="trailing" constant="20" id="HLX-6E-R18"/>
+                            <constraint firstItem="wG3-Mx-HDm" firstAttribute="top" secondItem="793-5d-Edp" secondAttribute="bottom" constant="59" id="bQt-3u-ojg"/>
+                            <constraint firstItem="hx8-uq-IDW" firstAttribute="trailing" secondItem="793-5d-Edp" secondAttribute="trailing" constant="20" id="lbZ-jx-ATW"/>
+                        </constraints>
                         <viewLayoutGuide key="safeArea" id="hx8-uq-IDW"/>
                     </view>
+                    <navigationItem key="navigationItem" id="eoA-yU-125">
+                        <barButtonItem key="rightBarButtonItem" title="Home" id="FE5-Fh-pvn"/>
+                    </navigationItem>
+                    <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wW0-tY-9mw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-15" y="149"/>
+            <point key="canvasLocation" x="-15.199999999999999" y="148.87556221889056"/>
         </scene>
     </scenes>
 </document>

--- a/spotterUITests/confirmTweetViewUITests.swift
+++ b/spotterUITests/confirmTweetViewUITests.swift
@@ -1,0 +1,36 @@
+//
+//  confirmTweetViewUITests.swift
+//  spotterUITests
+//
+//  Created by komei.nomura on 2017/10/03.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import XCTest
+
+class confirmTweetViewUITests: XCTestCase {
+        
+    override func setUp() {
+        super.setUp()
+
+        continueAfterFailure = false
+        XCUIApplication().launch()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testConfirmTweetView() {
+        let app = XCUIApplication()
+        app.buttons["Tweet確認画面へ"].tap()
+        XCTAssert(app.buttons["エモート"].exists)
+        
+        let tweetTextView = app.textViews["confirmTweetTextField"]
+        XCTAssert(tweetTextView.exists)
+        tweetTextView.tap()
+        tweetTextView.typeText("hello")
+        XCTAssertEqual("hello", tweetTextView.value as! String)
+    }
+    
+}


### PR DESCRIPTION
### 何を解決するのか

- ツイート確認を行う画面を作成

### 詳細

- `ConfirmTweet.storyboard`に画面を実装
    - テキストビューにツイートする内容が表示される予定
    - テキストの修正もできる予定
![image](https://user-images.githubusercontent.com/28612605/31114591-d2e220da-a859-11e7-99f1-c1f9f613249f.png)

- `confirmTweetViewUITests.swift`にツイート確認画面のテストを記述
    - 画面の要素の確認
    - textViewが編集できるかの確認

### レビューポイント

- 画面の構成

### レビュアー

@Fendo181 @Asuforce 

### 期限

速でお願いします！
