### PR TITLE
画面遷移を実装

### DIFF
--- a/spotter.xcodeproj/project.pbxproj
+++ b/spotter.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		BEC8E1011F85FB9D00AD1806 /* MusicTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = BEC8E0FF1F85FB9D00AD1806 /* MusicTableViewCell.xib */; };
 		BEC8E1031F85FC6000AD1806 /* SelectMusicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8E1021F85FC6000AD1806 /* SelectMusicViewController.swift */; };
 		BEC8E1061F8607F500AD1806 /* selectMusicViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8E1051F8607F500AD1806 /* selectMusicViewUITests.swift */; };
+		BECA063C1F87691200E9118A /* tweetTransitionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECA063B1F87691200E9118A /* tweetTransitionUITests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +90,7 @@
 		BEC8E0FF1F85FB9D00AD1806 /* MusicTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MusicTableViewCell.xib; sourceTree = "<group>"; };
 		BEC8E1021F85FC6000AD1806 /* SelectMusicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectMusicViewController.swift; sourceTree = "<group>"; };
 		BEC8E1051F8607F500AD1806 /* selectMusicViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = selectMusicViewUITests.swift; sourceTree = "<group>"; };
+		BECA063B1F87691200E9118A /* tweetTransitionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tweetTransitionUITests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -163,6 +165,7 @@
 		BEA4CB961F7A207B0066BF44 /* spotterUITests */ = {
 			isa = PBXGroup;
 			children = (
+				BECA063B1F87691200E9118A /* tweetTransitionUITests.swift */,
 				B7BE5B451F84BB1500CAFCD9 /* timelineViewUITest.swift */,
 				BEC8E1051F8607F500AD1806 /* selectMusicViewUITests.swift */,
 				BEC8E0F61F83546600AD1806 /* confirmTweetViewUITests.swift */,
@@ -445,6 +448,7 @@
 				BEC8E1061F8607F500AD1806 /* selectMusicViewUITests.swift in Sources */,
 				BEC8E0F71F83546600AD1806 /* confirmTweetViewUITests.swift in Sources */,
 				BE0495AE1F823CA0000D4630 /* tweetViewUITests.swift in Sources */,
+				BECA063C1F87691200E9118A /* tweetTransitionUITests.swift in Sources */,
 				B7BE5B461F84BB1500CAFCD9 /* timelineViewUITest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/spotter.xcodeproj/project.pbxproj
+++ b/spotter.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		B7BE5B461F84BB1500CAFCD9 /* timelineViewUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BE5B451F84BB1500CAFCD9 /* timelineViewUITest.swift */; };
 		B7CF62701F7CA1FB00908326 /* TimeLine.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B7CF626F1F7CA1FB00908326 /* TimeLine.storyboard */; };
 		BE0495AE1F823CA0000D4630 /* tweetViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE0495AD1F823CA0000D4630 /* tweetViewUITests.swift */; };
+		BE9AD4811F87505100B7E2AA /* ConfirmTweetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE9AD4801F87505100B7E2AA /* ConfirmTweetViewController.swift */; };
 		BEA4CB781F7A207B0066BF44 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CB771F7A207B0066BF44 /* AppDelegate.swift */; };
 		BEA4CB7F1F7A207B0066BF44 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BEA4CB7E1F7A207B0066BF44 /* Assets.xcassets */; };
 		BEA4CB8D1F7A207B0066BF44 /* spotterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEA4CB8C1F7A207B0066BF44 /* spotterTests.swift */; };
@@ -61,6 +62,7 @@
 		B7BE5B451F84BB1500CAFCD9 /* timelineViewUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = timelineViewUITest.swift; sourceTree = "<group>"; };
 		B7CF626F1F7CA1FB00908326 /* TimeLine.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TimeLine.storyboard; sourceTree = "<group>"; };
 		BE0495AD1F823CA0000D4630 /* tweetViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tweetViewUITests.swift; sourceTree = "<group>"; };
+		BE9AD4801F87505100B7E2AA /* ConfirmTweetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmTweetViewController.swift; sourceTree = "<group>"; };
 		BEA4CB741F7A207B0066BF44 /* spotter.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = spotter.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		BEA4CB771F7A207B0066BF44 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		BEA4CB7E1F7A207B0066BF44 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -188,6 +190,7 @@
 				BEC8E1021F85FC6000AD1806 /* SelectMusicViewController.swift */,
 				BEA4CBC11F7CC7E00066BF44 /* TweetViewController.swift */,
 				BEA4CBBD1F7BA82C0066BF44 /* LoginViewController.swift */,
+				BE9AD4801F87505100B7E2AA /* ConfirmTweetViewController.swift */,
 				B747ED851F81E2D100529310 /* TimeLineViewController.swift */,
 				BEA4CBB11F7A22EA0066BF44 /* ViewController.swift */,
 			);
@@ -417,6 +420,7 @@
 				BEA4CBC41F7CD0000066BF44 /* TweetTextView.swift in Sources */,
 				BEC8E1031F85FC6000AD1806 /* SelectMusicViewController.swift in Sources */,
 				BEA4CBB21F7A22EA0066BF44 /* ViewController.swift in Sources */,
+				BE9AD4811F87505100B7E2AA /* ConfirmTweetViewController.swift in Sources */,
 				BEA4CBC21F7CC7E00066BF44 /* TweetViewController.swift in Sources */,
 				BEC8E1001F85FB9D00AD1806 /* MusicTableViewCell.swift in Sources */,
 				BEA4CBBA1F7B8DB10066BF44 /* RoundRectButton.swift in Sources */,

--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -9,8 +9,7 @@
 import UIKit
 
 class ConfirmTweetViewController: UIViewController {
-
-
+    
     @IBAction func emoteButton(_ sender: Any) {
         dismiss(animated: true, completion: nil)
     }

--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -1,22 +1,18 @@
 //
-//  TweetViewController.swift
+//  ConfirmTweetViewController.swift
 //  spotter
 //
-//  Created by komei.nomura on 2017/09/28.
+//  Created by komei.nomura on 2017/10/06.
 //  Copyright © 2017年 GMO Pepabo. All rights reserved.
 //
 
 import UIKit
 
-class TweetViewController: UIViewController {
-    
+class ConfirmTweetViewController: UIViewController {
 
-    @IBAction func pushCloseButton(_ sender: Any) {
+
+    @IBAction func emoteButton(_ sender: Any) {
         dismiss(animated: true, completion: nil)
-    }
-    
-    @IBAction func pushEmotionButton(_ sender: Any) {
-        performSegue(withIdentifier: "goSelectMusic", sender: nil)
     }
     
     override func viewDidLoad() {

--- a/spotter/Classes/Controllers/SelectMusicViewController.swift
+++ b/spotter/Classes/Controllers/SelectMusicViewController.swift
@@ -36,5 +36,11 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
         
         return cell
     }
-
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        // セル選択
+        musicTableView.deselectRow(at: indexPath, animated: true)
+        
+        self.performSegue(withIdentifier: "toConfirmTweet", sender: nil)
+    }
 }

--- a/spotter/Classes/Controllers/SelectMusicViewController.swift
+++ b/spotter/Classes/Controllers/SelectMusicViewController.swift
@@ -41,6 +41,6 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
         // セル選択
         musicTableView.deselectRow(at: indexPath, animated: true)
         
-        self.performSegue(withIdentifier: "toConfirmTweet", sender: nil)
+        self.performSegue(withIdentifier: "goConfirmTweet", sender: nil)
     }
 }

--- a/spotter/Classes/Controllers/TweetViewController.swift
+++ b/spotter/Classes/Controllers/TweetViewController.swift
@@ -10,7 +10,6 @@ import UIKit
 
 class TweetViewController: UIViewController {
     
-
     @IBAction func pushCloseButton(_ sender: Any) {
         dismiss(animated: true, completion: nil)
     }

--- a/spotter/Storyboards/ConfirmTweet.storyboard
+++ b/spotter/Storyboards/ConfirmTweet.storyboard
@@ -12,7 +12,7 @@
         <!--confirmTweet-->
         <scene sceneID="h4Q-dM-ruc">
             <objects>
-                <viewController title="confirmTweet" id="nLb-0A-OFR" sceneMemberID="viewController">
+                <viewController title="confirmTweet" id="nLb-0A-OFR" customClass="ConfirmTweetViewController" customModule="spotter" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="oZe-XS-PGK">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -57,6 +57,9 @@
                                         <real key="value" value="20"/>
                                     </userDefinedRuntimeAttribute>
                                 </userDefinedRuntimeAttributes>
+                                <connections>
+                                    <action selector="emoteButton:" destination="nLb-0A-OFR" eventType="touchUpInside" id="VWZ-FD-Jiz"/>
+                                </connections>
                             </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>

--- a/spotter/Storyboards/ConfirmTweet.storyboard
+++ b/spotter/Storyboards/ConfirmTweet.storyboard
@@ -69,9 +69,7 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="hx8-uq-IDW"/>
                     </view>
-                    <navigationItem key="navigationItem" id="eoA-yU-125">
-                        <barButtonItem key="rightBarButtonItem" title="Home" id="FE5-Fh-pvn"/>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" id="eoA-yU-125"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wW0-tY-9mw" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/spotter/Storyboards/SelectMusic.storyboard
+++ b/spotter/Storyboards/SelectMusic.storyboard
@@ -58,7 +58,7 @@
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="musicTableView" destination="pvj-PX-ELt" id="3hP-MU-iQH"/>
-                        <segue destination="Ggs-MF-Tbv" kind="show" identifier="toConfirmTweet" id="Ao3-iv-eqL"/>
+                        <segue destination="Ggs-MF-Tbv" kind="show" identifier="goConfirmTweet" id="Ao3-iv-eqL"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="I6D-J0-zJM" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/spotter/Storyboards/SelectMusic.storyboard
+++ b/spotter/Storyboards/SelectMusic.storyboard
@@ -58,11 +58,20 @@
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <connections>
                         <outlet property="musicTableView" destination="pvj-PX-ELt" id="3hP-MU-iQH"/>
+                        <segue destination="Ggs-MF-Tbv" kind="show" identifier="toConfirmTweet" id="Ao3-iv-eqL"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="I6D-J0-zJM" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-108" y="126.38680659670166"/>
+        </scene>
+        <!--ConfirmTweet-->
+        <scene sceneID="Wg5-fm-DdL">
+            <objects>
+                <viewControllerPlaceholder storyboardName="ConfirmTweet" id="Ggs-MF-Tbv" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="viL-Kv-lEH" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="692" y="130"/>
         </scene>
     </scenes>
 </document>

--- a/spotter/Storyboards/TimeLine.storyboard
+++ b/spotter/Storyboards/TimeLine.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="wLR-WC-aud">
-    <device id="retina4_0" orientation="portrait">
+    <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -14,11 +14,11 @@
             <objects>
                 <viewController id="wLR-WC-aud" customClass="TimeLineViewController" customModule="spotter" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="DNT-Cl-xCG">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="timelineView" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="l2S-eh-BEE">
-                                <rect key="frame" x="0.0" y="141" width="320" height="427"/>
+                                <rect key="frame" x="0.0" y="141" width="375" height="526"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                 <sections/>
                                 <connections>
@@ -27,24 +27,17 @@
                                     <outlet property="prefetchDataSource" destination="wLR-WC-aud" id="qWc-AZ-0nU"/>
                                 </connections>
                             </tableView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="komei" translatesAutoresizingMaskIntoConstraints="NO" id="8tI-pk-sOX">
-                                <rect key="frame" x="20" y="23" width="78" height="78"/>
-                                <accessibility key="accessibilityConfiguration" identifier="profileImage">
-                                    <bool key="isElement" value="YES"/>
-                                </accessibility>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="78" id="5JL-j4-C7d"/>
-                                    <constraint firstAttribute="width" constant="78" id="ciZ-FN-1mu"/>
-                                </constraints>
-                            </imageView>
                             <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8O2-Mo-bzl">
-                                <rect key="frame" x="199" y="23" width="77" height="77"/>
+                                <rect key="frame" x="254" y="23" width="77" height="77"/>
                                 <accessibility key="accessibilityConfiguration" identifier="tweetButton"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="77" id="st0-jd-9nZ"/>
                                     <constraint firstAttribute="height" constant="77" id="z4l-r4-AOm"/>
                                 </constraints>
                                 <state key="normal" title="Button" image="pen"/>
+                                <connections>
+                                    <segue destination="3Rs-05-xkj" kind="presentation" id="Jjl-ZE-rEC"/>
+                                </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="こーめい" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O3Z-lT-786">
                                 <rect key="frame" x="24" y="109" width="70" height="21"/>
@@ -57,6 +50,16 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="komei" translatesAutoresizingMaskIntoConstraints="NO" id="8tI-pk-sOX">
+                                <rect key="frame" x="20" y="23" width="78" height="78"/>
+                                <accessibility key="accessibilityConfiguration" identifier="profileImage">
+                                    <bool key="isElement" value="YES"/>
+                                </accessibility>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="78" id="5JL-j4-C7d"/>
+                                    <constraint firstAttribute="width" constant="78" id="ciZ-FN-1mu"/>
+                                </constraints>
+                            </imageView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
@@ -81,6 +84,14 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qUH-dO-jWr" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-690" y="-61.267605633802816"/>
+        </scene>
+        <!--Tweet-->
+        <scene sceneID="d04-bp-WF8">
+            <objects>
+                <viewControllerPlaceholder storyboardName="Tweet" id="3Rs-05-xkj" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Mdd-Gs-7xa" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="19" y="-107"/>
         </scene>
     </scenes>
     <resources>

--- a/spotter/Storyboards/TimeLine.storyboard
+++ b/spotter/Storyboards/TimeLine.storyboard
@@ -17,16 +17,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="timelineView" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="l2S-eh-BEE">
-                                <rect key="frame" x="0.0" y="141" width="375" height="526"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <sections/>
-                                <connections>
-                                    <outlet property="dataSource" destination="wLR-WC-aud" id="plx-q0-oQb"/>
-                                    <outlet property="delegate" destination="wLR-WC-aud" id="BbA-ct-VSZ"/>
-                                    <outlet property="prefetchDataSource" destination="wLR-WC-aud" id="qWc-AZ-0nU"/>
-                                </connections>
-                            </tableView>
                             <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8O2-Mo-bzl">
                                 <rect key="frame" x="254" y="23" width="77" height="77"/>
                                 <accessibility key="accessibilityConfiguration" identifier="tweetButton"/>
@@ -60,6 +50,16 @@
                                     <constraint firstAttribute="width" constant="78" id="ciZ-FN-1mu"/>
                                 </constraints>
                             </imageView>
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="timelineView" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="l2S-eh-BEE">
+                                <rect key="frame" x="0.0" y="141" width="375" height="526"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <sections/>
+                                <connections>
+                                    <outlet property="dataSource" destination="wLR-WC-aud" id="plx-q0-oQb"/>
+                                    <outlet property="delegate" destination="wLR-WC-aud" id="BbA-ct-VSZ"/>
+                                    <outlet property="prefetchDataSource" destination="wLR-WC-aud" id="qWc-AZ-0nU"/>
+                                </connections>
+                            </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>

--- a/spotter/Storyboards/Tweet.storyboard
+++ b/spotter/Storyboards/Tweet.storyboard
@@ -160,9 +160,7 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="QSj-Bs-TFw"/>
                     </view>
-                    <navigationItem key="navigationItem" id="u8K-Bh-q5L">
-                        <barButtonItem key="rightBarButtonItem" title="Home" id="Jm5-jk-KUb"/>
-                    </navigationItem>
+                    <navigationItem key="navigationItem" id="u8K-Bh-q5L"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3Ah-fN-XFe" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/spotter/Storyboards/Tweet.storyboard
+++ b/spotter/Storyboards/Tweet.storyboard
@@ -61,6 +61,9 @@
                                                 <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="Q6p-yq-dCg" kind="show" id="ByB-I0-xkj"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Gr-Yj-KjK" customClass="RoundRectButton" customModule="spotter" customModuleProvider="target">
                                         <rect key="frame" x="166" y="0.0" width="162" height="67"/>
@@ -81,6 +84,9 @@
                                                 <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="Q6p-yq-dCg" kind="show" id="TJU-Ga-pCj"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <constraints>
@@ -109,6 +115,9 @@
                                                 <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="Q6p-yq-dCg" kind="show" id="czJ-dO-Bib"/>
+                                        </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dcJ-WN-WsA" customClass="RoundRectButton" customModule="spotter" customModuleProvider="target">
                                         <rect key="frame" x="166" y="0.0" width="162" height="67"/>
@@ -129,6 +138,9 @@
                                                 <color key="value" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
+                                        <connections>
+                                            <segue destination="Q6p-yq-dCg" kind="show" id="Hso-Vr-VdX"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <constraints>
@@ -166,6 +178,14 @@
             </objects>
             <point key="canvasLocation" x="200.80000000000001" y="98.50074962518741"/>
         </scene>
+        <!--SelectMusic-->
+        <scene sceneID="pA5-qJ-739">
+            <objects>
+                <viewControllerPlaceholder storyboardName="SelectMusic" id="Q6p-yq-dCg" sceneMemberID="viewController"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="mYd-Ir-GEg" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="992" y="154"/>
+        </scene>
         <!--Navigation Controller-->
         <scene sceneID="oC2-gZ-4aL">
             <objects>
@@ -185,4 +205,7 @@
             <point key="canvasLocation" x="-649" y="99"/>
         </scene>
     </scenes>
+    <inferredMetricsTieBreakers>
+        <segue reference="Hso-Vr-VdX"/>
+    </inferredMetricsTieBreakers>
 </document>

--- a/spotter/Storyboards/Tweet.storyboard
+++ b/spotter/Storyboards/Tweet.storyboard
@@ -18,27 +18,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="d3T-7r-DrF" customClass="TweetTextView" customModule="spotter" customModuleProvider="target">
-                                <rect key="frame" x="20" y="88" width="335" height="160"/>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <accessibility key="accessibilityConfiguration" identifier="tweetTextField"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="d3T-7r-DrF" secondAttribute="height" multiplier="67:32" id="DP8-LF-lb8"/>
-                                </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
-                                        <color key="value" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
-                                        <real key="value" value="2"/>
-                                    </userDefinedRuntimeAttribute>
-                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                        <real key="value" value="6"/>
-                                    </userDefinedRuntimeAttribute>
-                                </userDefinedRuntimeAttributes>
-                            </textView>
                             <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="W2X-6t-UHd">
                                 <rect key="frame" x="20" y="353" width="328" height="67"/>
                                 <subviews>
@@ -154,6 +133,27 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="d3T-7r-DrF" customClass="TweetTextView" customModule="spotter" customModuleProvider="target">
+                                <rect key="frame" x="20" y="88" width="335" height="160"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <accessibility key="accessibilityConfiguration" identifier="tweetTextField"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="d3T-7r-DrF" secondAttribute="height" multiplier="67:32" id="DP8-LF-lb8"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                <userDefinedRuntimeAttributes>
+                                    <userDefinedRuntimeAttribute type="color" keyPath="borderColor">
+                                        <color key="value" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="borderWidth">
+                                        <real key="value" value="2"/>
+                                    </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
+                                        <real key="value" value="6"/>
+                                    </userDefinedRuntimeAttribute>
+                                </userDefinedRuntimeAttributes>
+                            </textView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>

--- a/spotter/Storyboards/Tweet.storyboard
+++ b/spotter/Storyboards/Tweet.storyboard
@@ -62,7 +62,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <segue destination="Q6p-yq-dCg" kind="show" id="ByB-I0-xkj"/>
+                                            <action selector="pushEmotionButton:" destination="hKa-NW-TGy" eventType="touchUpInside" id="HBw-G0-Wyq"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4Gr-Yj-KjK" customClass="RoundRectButton" customModule="spotter" customModuleProvider="target">
@@ -85,7 +85,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <segue destination="Q6p-yq-dCg" kind="show" id="TJU-Ga-pCj"/>
+                                            <action selector="pushEmotionButton:" destination="hKa-NW-TGy" eventType="touchUpInside" id="Jra-c0-zmD"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -116,7 +116,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <segue destination="Q6p-yq-dCg" kind="show" id="czJ-dO-Bib"/>
+                                            <action selector="pushEmotionButton:" destination="hKa-NW-TGy" eventType="touchUpInside" id="Uxj-CB-KgW"/>
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dcJ-WN-WsA" customClass="RoundRectButton" customModule="spotter" customModuleProvider="target">
@@ -139,7 +139,7 @@
                                             </userDefinedRuntimeAttribute>
                                         </userDefinedRuntimeAttributes>
                                         <connections>
-                                            <segue destination="Q6p-yq-dCg" kind="show" id="Hso-Vr-VdX"/>
+                                            <action selector="pushEmotionButton:" destination="hKa-NW-TGy" eventType="touchUpInside" id="dj3-7u-M9f"/>
                                         </connections>
                                     </button>
                                 </subviews>
@@ -172,7 +172,16 @@
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="QSj-Bs-TFw"/>
                     </view>
-                    <navigationItem key="navigationItem" id="u8K-Bh-q5L"/>
+                    <navigationItem key="navigationItem" id="u8K-Bh-q5L">
+                        <barButtonItem key="leftBarButtonItem" systemItem="stop" id="UV9-xz-pPa">
+                            <connections>
+                                <action selector="pushCloseButton:" destination="hKa-NW-TGy" id="Icb-iO-DMt"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <segue destination="Q6p-yq-dCg" kind="show" identifier="goSelectMusic" id="wQ1-X0-2St"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="3Ah-fN-XFe" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
@@ -205,7 +214,4 @@
             <point key="canvasLocation" x="-649" y="99"/>
         </scene>
     </scenes>
-    <inferredMetricsTieBreakers>
-        <segue reference="Hso-Vr-VdX"/>
-    </inferredMetricsTieBreakers>
 </document>

--- a/spotterUITests/tweetTransitionUITests.swift
+++ b/spotterUITests/tweetTransitionUITests.swift
@@ -51,7 +51,6 @@ class tweetTransitionUITest: XCTestCase {
     }
     
     func testNavigationBarTransition() {
-        
         let app = XCUIApplication()
         app.buttons["タイムライン画面"].tap()
         // ツイート画面へ

--- a/spotterUITests/tweetTransitionUITests.swift
+++ b/spotterUITests/tweetTransitionUITests.swift
@@ -1,0 +1,80 @@
+//
+//  tweetTransitionUITests.swift
+//  spotterUITests
+//
+//  Created by komei.nomura on 2017/10/06.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import XCTest
+
+class tweetTransitionUITest: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        XCUIApplication().launch()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testTweetScreenTransition() {
+        let app = XCUIApplication()
+        
+        // タイムライン画面へ
+        app.buttons["タイムライン画面"].tap()
+        XCTAssert(app.images["profileImage"].exists)
+        
+        // ツイート画面へ
+        app/*@START_MENU_TOKEN@*/.buttons["tweetButton"]/*[[".buttons[\"Button\"]",".buttons[\"tweetButton\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        sleep(1)
+        XCTAssertFalse(app.images["profileImage"].exists)
+        XCTAssert(app.textViews["tweetTextField"].exists)
+        
+        // 曲選択画面へ
+        app.buttons["#嬉しい"].tap()
+        sleep(1)
+        XCTAssertFalse(app.textViews["tweetTextField"].exists)
+        XCTAssert(app.tables.element(boundBy: 0).exists)
+        
+        // ツイート確認画面へ
+        app.tables.children(matching: .cell).element(boundBy: 0).staticTexts["hogefugapiyohogehoge"].tap()
+        XCTAssertFalse(app.tables.element(boundBy: 0).exists)
+        XCTAssert(app.textViews["confirmTweetTextField"].exists)
+        
+        // ツイートしてタイムライン画面へ
+        app.buttons["エモート"].tap()
+        XCTAssertFalse(app.textViews["confirmTweetTextField"].exists)
+        XCTAssert(app.images["profileImage"].exists)
+    }
+    
+    func testNavigationBarTransition() {
+        
+        let app = XCUIApplication()
+        app.buttons["タイムライン画面"].tap()
+        // ツイート画面へ
+        app/*@START_MENU_TOKEN@*/.buttons["tweetButton"]/*[[".buttons[\"Button\"]",".buttons[\"tweetButton\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        sleep(1)
+        XCTAssertFalse(app.images["profileImage"].exists)
+        XCTAssert(app.textViews["tweetTextField"].exists)
+        
+        // 曲選択画面へ
+        app.buttons["#楽しい"].tap()
+        sleep(1)
+        XCTAssertFalse(app.textViews["tweetTextField"].exists)
+        XCTAssert(app.tables.element(boundBy: 0).exists)
+        
+        // ツイート画面へ（NavigationBarを使って）
+        app.navigationBars["spotter.SelectMusicView"].buttons["Back"].tap()
+        XCTAssertFalse(app.tables.element(boundBy: 0).exists)
+        XCTAssert(app.textViews["tweetTextField"].exists)
+        
+        // タイムライン画面へ
+        app.navigationBars.buttons["Stop"].tap()
+        XCTAssertFalse(app.textViews["tweetTextField"].exists)
+        XCTAssert(app.images["profileImage"].exists)
+    }
+    
+}


### PR DESCRIPTION
### 何を解決するのか

- タイムライン画面からツイート確認画面までの画面遷移を実装
<img src="https://user-images.githubusercontent.com/28612605/31273099-38cbbd1e-aac8-11e7-8257-c45e71eb9d12.gif" width="200">



- ツイートを途中でやめたり戻ったりする画面遷移を実装
<img src="https://user-images.githubusercontent.com/28612605/31273111-3e9577bc-aac8-11e7-8dcd-9b67a2c5a1fd.gif" width="200">


### 詳細

- `TimeLine.storyboard`
    - 鉛筆ボタンに対してセグエを設定して遷移
    - 遷移形式はモーダル遷移
- `Tweet.storyboard`
    - TweetViewControllerに対してセグエを設定
    - モーダルViewを閉じるためのボタンをNavigationBarの左上に設置
        - TimeLine画面に戻る
-`TweetViewController`
    - それぞれの感情ボタンに対して共通のアクションを追加（pushEmotionButton）
    - 閉じるボタンを押したときにモーダルViewを閉じるためのアクションを追加（pushCloseButton）
- `SelectMusic.storyboard`
    - テーブルの要素をタップすると遷移するよう実装
- `SelectMusicController`
    - セルを選択したときの処理を追加
- `ConfirmTweet.storyboard`
    - エモートボタンを押したときにモーダルViewを閉じるように実装
- `ConfirmTweetViewController`
    - モーダルViewを閉じる処理を追加

### レビューポイント

- 遷移のフローが正しいか
- 遷移の実装

### レビュアー

@Fendo181 @Asuforce 

### 期限

なる速でお願いします！
