### PR TITLE
曲選択画面からツイート確認画面への値の引き渡しの実装

### DIFF
--- a/spotter.xcodeproj/project.pbxproj
+++ b/spotter.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		BEC8E1031F85FC6000AD1806 /* SelectMusicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8E1021F85FC6000AD1806 /* SelectMusicViewController.swift */; };
 		BEC8E1061F8607F500AD1806 /* selectMusicViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8E1051F8607F500AD1806 /* selectMusicViewUITests.swift */; };
 		BECA063C1F87691200E9118A /* tweetTransitionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECA063B1F87691200E9118A /* tweetTransitionUITests.swift */; };
+		BEE4DEE51F9060E8004B2F94 /* Music.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE4DEE41F9060E8004B2F94 /* Music.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +92,7 @@
 		BEC8E1021F85FC6000AD1806 /* SelectMusicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectMusicViewController.swift; sourceTree = "<group>"; };
 		BEC8E1051F8607F500AD1806 /* selectMusicViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = selectMusicViewUITests.swift; sourceTree = "<group>"; };
 		BECA063B1F87691200E9118A /* tweetTransitionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tweetTransitionUITests.swift; sourceTree = "<group>"; };
+		BEE4DEE41F9060E8004B2F94 /* Music.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Music.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -210,6 +212,7 @@
 		BEA4CBA91F7A21BA0066BF44 /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				BEE4DEE41F9060E8004B2F94 /* Music.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -430,6 +433,7 @@
 				BEA4CB781F7A207B0066BF44 /* AppDelegate.swift in Sources */,
 				B747ED891F81EFEB00529310 /* TimelineTableViewCell.swift in Sources */,
 				B747ED861F81E2D100529310 /* TimeLineViewController.swift in Sources */,
+				BEE4DEE51F9060E8004B2F94 /* Music.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -12,6 +12,10 @@ class ConfirmTweetViewController: UIViewController {
     
     var tweetText = ""
     var emotionText = ""
+    var musicName = ""
+    var musicURL = ""
+    
+    @IBOutlet weak var tweetTextView: TweetTextView!
     
     @IBAction func emoteButton(_ sender: Any) {
         dismiss(animated: true, completion: nil)
@@ -19,6 +23,8 @@ class ConfirmTweetViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        tweetTextView.text = "\(tweetText)\n\(emotionText)\n\(musicName)(\(musicURL))"
     }
 
     override func didReceiveMemoryWarning() {

--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -10,6 +10,9 @@ import UIKit
 
 class ConfirmTweetViewController: UIViewController {
     
+    var tweetText = ""
+    var emotionText = ""
+    
     @IBAction func emoteButton(_ sender: Any) {
         dismiss(animated: true, completion: nil)
     }

--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -12,8 +12,7 @@ class ConfirmTweetViewController: UIViewController {
     
     var tweetText = ""
     var emotionText = ""
-    var musicName = ""
-    var musicURL = ""
+    var music = Music()
     
     @IBOutlet weak var tweetTextView: TweetTextView!
     
@@ -24,7 +23,7 @@ class ConfirmTweetViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        tweetTextView.text = "\(tweetText)\n\(emotionText)\n\(musicName)(\(musicURL))"
+        tweetTextView.text = "\(tweetText)\n\(emotionText)\n\(music.name)(\(music.url))"
     }
 
     override func didReceiveMemoryWarning() {

--- a/spotter/Classes/Controllers/SelectMusicViewController.swift
+++ b/spotter/Classes/Controllers/SelectMusicViewController.swift
@@ -57,7 +57,7 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cell = musicTableView.cellForRow(at: indexPath) as! MusicTableViewCell
         music.name = cell.musicLabel.text!
-        music.url = "http://hogehoge"
+        music.url = "http://example.com"
         musicTableView.deselectRow(at: indexPath, animated: true)
         self.performSegue(withIdentifier: "goConfirmTweet", sender: nil)
     }

--- a/spotter/Classes/Controllers/SelectMusicViewController.swift
+++ b/spotter/Classes/Controllers/SelectMusicViewController.swift
@@ -31,6 +31,14 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
         super.didReceiveMemoryWarning()
     }
     
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if(segue.identifier == "goConfirmTweet") {
+            let confirmTweetViewController: ConfirmTweetViewController = segue.destination as! ConfirmTweetViewController
+            confirmTweetViewController.emotionText = emotionText
+            confirmTweetViewController.tweetText = tweetText
+        }
+    }
+    
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return 3
     }

--- a/spotter/Classes/Controllers/SelectMusicViewController.swift
+++ b/spotter/Classes/Controllers/SelectMusicViewController.swift
@@ -12,6 +12,9 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
     
     var tweetText = ""
     var emotionText = ""
+    var musicName = ""
+    var musicURL = ""
+    
     
     @IBOutlet weak var emotionLabel: UILabel!
     
@@ -36,6 +39,8 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
             let confirmTweetViewController: ConfirmTweetViewController = segue.destination as! ConfirmTweetViewController
             confirmTweetViewController.emotionText = emotionText
             confirmTweetViewController.tweetText = tweetText
+            confirmTweetViewController.musicURL = musicURL
+            confirmTweetViewController.musicName = musicName
         }
     }
     
@@ -53,9 +58,11 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        // セル選択
-        musicTableView.deselectRow(at: indexPath, animated: true)
+        let cell = musicTableView.cellForRow(at: indexPath) as! MusicTableViewCell
         
+        musicName = cell.musicLabel.text!
+        musicURL = "http://hogehoge"
+        musicTableView.deselectRow(at: indexPath, animated: true)
         self.performSegue(withIdentifier: "goConfirmTweet", sender: nil)
     }
 }

--- a/spotter/Classes/Controllers/SelectMusicViewController.swift
+++ b/spotter/Classes/Controllers/SelectMusicViewController.swift
@@ -12,9 +12,7 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
     
     var tweetText = ""
     var emotionText = ""
-    var musicName = ""
-    var musicURL = ""
-    
+    var music = Music()
     
     @IBOutlet weak var emotionLabel: UILabel!
     
@@ -39,8 +37,7 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
             let confirmTweetViewController: ConfirmTweetViewController = segue.destination as! ConfirmTweetViewController
             confirmTweetViewController.emotionText = emotionText
             confirmTweetViewController.tweetText = tweetText
-            confirmTweetViewController.musicURL = musicURL
-            confirmTweetViewController.musicName = musicName
+            confirmTweetViewController.music = music
         }
     }
     
@@ -59,9 +56,8 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cell = musicTableView.cellForRow(at: indexPath) as! MusicTableViewCell
-        
-        musicName = cell.musicLabel.text!
-        musicURL = "http://hogehoge"
+        music.name = cell.musicLabel.text!
+        music.url = "http://hogehoge"
         musicTableView.deselectRow(at: indexPath, animated: true)
         self.performSegue(withIdentifier: "goConfirmTweet", sender: nil)
     }

--- a/spotter/Classes/Models/Music.swift
+++ b/spotter/Classes/Models/Music.swift
@@ -1,0 +1,14 @@
+//
+//  Music.swift
+//  spotter
+//
+//  Created by komei.nomura on 2017/10/13.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+
+class Music {
+    var name: String = ""
+    var url: String = ""
+}

--- a/spotter/Storyboards/ConfirmTweet.storyboard
+++ b/spotter/Storyboards/ConfirmTweet.storyboard
@@ -74,6 +74,9 @@
                     </view>
                     <navigationItem key="navigationItem" id="eoA-yU-125"/>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
+                    <connections>
+                        <outlet property="tweetTextView" destination="793-5d-Edp" id="clL-NO-OGF"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="wW0-tY-9mw" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/spotterUITests/confirmTweetViewUITests.swift
+++ b/spotterUITests/confirmTweetViewUITests.swift
@@ -34,9 +34,11 @@ class confirmTweetViewUITests: XCTestCase {
         let emotionButtonText = "#嬉しい"
         app.buttons[emotionButtonText].tap()
         let musicLabel = "hogefugapiyohogehoge"
-        let musicURL = "http://hogehoge"
+        let musicURL = "http://example.com"
         app.tables.children(matching: .cell).element(boundBy: 0).staticTexts[musicLabel].tap()
+        sleep(1)
         let confirmTweetText = app.textViews["confirmTweetTextField"].value as! String
+        print("\(tweetText)\n\(emotionButtonText)\n\(musicLabel)(\(musicURL))")
         XCTAssertEqual("\(tweetText)\n\(emotionButtonText)\n\(musicLabel)(\(musicURL))", confirmTweetText)
 
     }

--- a/spotterUITests/confirmTweetViewUITests.swift
+++ b/spotterUITests/confirmTweetViewUITests.swift
@@ -22,15 +22,23 @@ class confirmTweetViewUITests: XCTestCase {
     }
     
     func testConfirmTweetView() {
-        let app = XCUIApplication()
-        app.buttons["Tweet確認画面へ"].tap()
-        XCTAssert(app.buttons["エモート"].exists)
         
-        let tweetTextView = app.textViews["confirmTweetTextField"]
-        XCTAssert(tweetTextView.exists)
-        tweetTextView.tap()
-        tweetTextView.typeText("hello")
-        XCTAssertEqual("hello", tweetTextView.value as! String)
+        let app = XCUIApplication()
+        app.buttons["タイムライン画面"].tap()
+        app/*@START_MENU_TOKEN@*/.buttons["tweetButton"]/*[[".buttons[\"Button\"]",".buttons[\"tweetButton\"]"],[[[-1,1],[-1,0]]],[0]]@END_MENU_TOKEN@*/.tap()
+        
+        let tweettextfieldTextView = app.textViews["tweetTextField"]
+        tweettextfieldTextView.tap()
+        let tweetText = "Hello"
+        tweettextfieldTextView.typeText(tweetText)
+        let emotionButtonText = "#嬉しい"
+        app.buttons[emotionButtonText].tap()
+        let musicLabel = "hogefugapiyohogehoge"
+        let musicURL = "http://hogehoge"
+        app.tables.children(matching: .cell).element(boundBy: 0).staticTexts[musicLabel].tap()
+        let confirmTweetText = app.textViews["confirmTweetTextField"].value as! String
+        XCTAssertEqual("\(tweetText)\n\(emotionButtonText)\n\(musicLabel)(\(musicURL))", confirmTweetText)
+
     }
     
 }


### PR DESCRIPTION
### 何を解決するのか

- ツイート画面からツイート確認画面までの必要な値の引き渡しができるようになる

#### 動作
<img src="https://user-images.githubusercontent.com/28612605/31529444-4b926820-b014-11e7-9bf0-7e2060ac6ad8.gif" width="200">

### 詳細

- `ConfirmTweetViewController`
    - 値引き渡しのための変数を追加
    - viewDidLoad時に渡されてきた値をもとにテキストを表示するようにした
- `SelectMusicViewController`
    - 選択されたセルの曲の情報を値引き渡しのための変数に保存する処理を追加
    - `prepare`関数で値引き渡しの処理を記述
- `Music`モデル
    - 曲に関するデータを保存するモデルを追加
    - 後々fetchする処理などもここに書けると思う

### レビューポイント

- 値引き渡しの処理

### レビュアー

@Asuforce @Fendo181 

### 期限

なる速でお願いします！
