### PR TITLE
view間の値の引き渡しにMicropostモデルを利用するように実装

### DIFF
--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class ConfirmTweetViewController: UIViewController {
     
-    var tweetText = ""
+    var micropost = Micropost(userID: 0, content: "")
     var emotionText = ""
     var music = Music()
     
@@ -23,7 +23,7 @@ class ConfirmTweetViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        tweetTextView.text = "\(tweetText)\n\(emotionText)\n\(music.name)(\(music.url))"
+        tweetTextView.text = "\(micropost.content)\n\(emotionText)\n\(music.name)(\(music.url))"
     }
 
     override func didReceiveMemoryWarning() {

--- a/spotter/Classes/Controllers/SelectMusicViewController.swift
+++ b/spotter/Classes/Controllers/SelectMusicViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
     
-    var tweetText = ""
+    var micropost = Micropost(userID: 0, content: "")
     var emotionText = ""
     var music = Music()
     
@@ -36,7 +36,7 @@ class SelectMusicViewController: UIViewController, UITableViewDelegate, UITableV
         if(segue.identifier == "goConfirmTweet") {
             let confirmTweetViewController: ConfirmTweetViewController = segue.destination as! ConfirmTweetViewController
             confirmTweetViewController.emotionText = emotionText
-            confirmTweetViewController.tweetText = tweetText
+            confirmTweetViewController.micropost = micropost
             confirmTweetViewController.music = music
         }
     }

--- a/spotter/Classes/Controllers/TimeLineViewController.swift
+++ b/spotter/Classes/Controllers/TimeLineViewController.swift
@@ -47,6 +47,15 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         return cell
     }
     
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        if (segue.identifier == "goTweet") {
+            if let navigationController = segue.destination as? UINavigationController {
+                let tweetViewController: TweetViewController = navigationController.topViewController as! TweetViewController
+                tweetViewController.micropost = Micropost(userID: userID, content: "")
+            }
+        }
+    }
+    
     private func setTimelineViewElements() {
         Users.fetchUsers(userID: userID) { users in
             self.userImageURL = users.imgURL
@@ -58,6 +67,5 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
             self.microposts = microposts.reversed()
             self.timelineView.reloadData()
         }
-        
     }
 }

--- a/spotter/Classes/Controllers/TweetViewController.swift
+++ b/spotter/Classes/Controllers/TweetViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 class TweetViewController: UIViewController {
     
+    var micropost = Micropost(userID: 0, content: "")
     var emotionText = ""
     
     @IBOutlet weak var tweetTextView: TweetTextView!
@@ -33,6 +34,7 @@ class TweetViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        dump(micropost)
     }
 
     override func didReceiveMemoryWarning() {

--- a/spotter/Classes/Controllers/TweetViewController.swift
+++ b/spotter/Classes/Controllers/TweetViewController.swift
@@ -21,20 +21,20 @@ class TweetViewController: UIViewController {
     
     @IBAction func pushEmotionButton(_ sender: UIButton) {
         emotionText = sender.currentTitle!
+        micropost.content = tweetTextView.text
         performSegue(withIdentifier: "goSelectMusic", sender: nil)
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if (segue.identifier == "goSelectMusic") {
             let selectMusicViewController: SelectMusicViewController = segue.destination as! SelectMusicViewController
-            selectMusicViewController.tweetText = tweetTextView.text
+            selectMusicViewController.micropost = micropost
             selectMusicViewController.emotionText = emotionText
         }
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        dump(micropost)
     }
 
     override func didReceiveMemoryWarning() {

--- a/spotter/Storyboards/TimeLine.storyboard
+++ b/spotter/Storyboards/TimeLine.storyboard
@@ -26,7 +26,7 @@
                                 </constraints>
                                 <state key="normal" title="Button" image="pen"/>
                                 <connections>
-                                    <segue destination="3Rs-05-xkj" kind="presentation" id="Jjl-ZE-rEC"/>
+                                    <segue destination="3Rs-05-xkj" kind="presentation" identifier="goTweet" id="Jjl-ZE-rEC"/>
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="こーめい" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O3Z-lT-786">


### PR DESCRIPTION
### 何を解決するのか

- view間の値渡しをMicropostモデルを利用するように変更
    - user_idとmicropostのコンテントをまとめて渡せるので変数が一つ減る
- user_idをツイート確認画面まで値渡しできるようになる
    - 結果、POSTに必要な情報がツイート確認画面で揃う

### 詳細

- `TimeLineViewController`
    - Micropostモデルのインスタンスを作成
    - `micropost.userId`をセットして`micropost`インスタンスを次のビューに値渡し
- 次の順に値渡しが行われる
    - `TimeLineViewController`→`TweetViewController`
        - 渡すもの：user_id
    - `TweetViewController` →`SelectMusicViewController`
        - 渡すもの：Micropostモデル、感情ボタンのラベル
    - `SelectMusicViewController`→`ConfirmTweetViewController`
        - 渡すもの：Micropostモデル、感情ボタンのラベル、音楽モデル、


### レビューポイント

- 値渡しの処理

### レビュアー

@Fendo181 @Asuforce 

### 期限

なる速でお願いします！
