### PR TITLE
TextView以外をタップしたときソフトウェアキーボード消すように変更

### DIFF
--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -29,5 +29,9 @@ class ConfirmTweetViewController: UIViewController {
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
     }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
+    }
 
 }

--- a/spotter/Classes/Controllers/TweetViewController.swift
+++ b/spotter/Classes/Controllers/TweetViewController.swift
@@ -25,6 +25,14 @@ class TweetViewController: UIViewController {
         performSegue(withIdentifier: "goSelectMusic", sender: nil)
     }
     
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    override func didReceiveMemoryWarning() {
+        super.didReceiveMemoryWarning()
+    }
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if (segue.identifier == "goSelectMusic") {
             let selectMusicViewController: SelectMusicViewController = segue.destination as! SelectMusicViewController
@@ -33,12 +41,8 @@ class TweetViewController: UIViewController {
         }
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.view.endEditing(true)
     }
-
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-    }
-
+    
 }


### PR DESCRIPTION
### 何を解決するのか

- textViewをタップしてソフトウェアキーボードで入力したあと、別の場所をタップしてもキーボードが隠れない問題を修正

### 詳細

- touchesBeganメソッドをオーバーライドして、textView以外のところをタップしたときにキーボードが隠れるように実装

### レビュアー

@Asuforce @Fendo181 

### 期限
なる速でお願いします！
