### PR TITLE
MicropostをPOSTする機能を実装

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,4 @@
 github "Alamofire/Alamofire"
 github "SwiftyJSON/SwiftyJSON"
 github "onevcat/Kingfisher"
+github "AliSoftware/OHHTTPStubs"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,4 @@
 github "Alamofire/Alamofire" "4.5.1"
+github "AliSoftware/OHHTTPStubs" "6.0.0"
 github "SwiftyJSON/SwiftyJSON" "3.1.4"
-github "onevcat/Kingfisher" "4.1.0"
+github "onevcat/Kingfisher" "4.1.1"

--- a/spotter.xcodeproj/project.pbxproj
+++ b/spotter.xcodeproj/project.pbxproj
@@ -440,10 +440,12 @@
 				"$(SRCROOT)/Carthage/Build/iOS/Alamofire.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/SwiftyJSON.framework",
 				"$(SRCROOT)/Carthage/Build/iOS/Kingfisher.framework",
+				"$(SRCROOT)/Carthage/Build/iOS/OHHTTPStubs.framework",
 			);
 			outputPaths = (
 				"$(DERIVED_FILE_DIR)/Carthage/Build/iOS/Alamofire.framework",
 				"$(DERIVED_FILE_DIR)/Carthage/Build/iOS/SwiftyJSON.framework",
+				"$(DERIVED_FILE_DIR)//Carthage/Build/iOS/OHHTTPStubs.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/spotter.xcodeproj/project.pbxproj
+++ b/spotter.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		BEC8E1031F85FC6000AD1806 /* SelectMusicViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8E1021F85FC6000AD1806 /* SelectMusicViewController.swift */; };
 		BEC8E1061F8607F500AD1806 /* selectMusicViewUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC8E1051F8607F500AD1806 /* selectMusicViewUITests.swift */; };
 		BECA063C1F87691200E9118A /* tweetTransitionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECA063B1F87691200E9118A /* tweetTransitionUITests.swift */; };
+		BECD03CA1F972000006199CA /* successCreateMicropost.json in Resources */ = {isa = PBXBuildFile; fileRef = BECD03C91F972000006199CA /* successCreateMicropost.json */; };
+		BECD03CC1F972182006199CA /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BECD03CB1F972181006199CA /* OHHTTPStubs.framework */; };
 		BEE4DEE51F9060E8004B2F94 /* Music.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE4DEE41F9060E8004B2F94 /* Music.swift */; };
 /* End PBXBuildFile section */
 
@@ -104,6 +106,8 @@
 		BEC8E1021F85FC6000AD1806 /* SelectMusicViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectMusicViewController.swift; sourceTree = "<group>"; };
 		BEC8E1051F8607F500AD1806 /* selectMusicViewUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = selectMusicViewUITests.swift; sourceTree = "<group>"; };
 		BECA063B1F87691200E9118A /* tweetTransitionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tweetTransitionUITests.swift; sourceTree = "<group>"; };
+		BECD03C91F972000006199CA /* successCreateMicropost.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = successCreateMicropost.json; sourceTree = "<group>"; };
+		BECD03CB1F972181006199CA /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
 		BEE4DEE41F9060E8004B2F94 /* Music.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Music.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -122,6 +126,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BECD03CC1F972182006199CA /* OHHTTPStubs.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -171,6 +176,7 @@
 		BEA4CB8B1F7A207B0066BF44 /* spotterTests */ = {
 			isa = PBXGroup;
 			children = (
+				BECD03C81F972000006199CA /* StubFiles */,
 				BEA4CB8C1F7A207B0066BF44 /* spotterTests.swift */,
 				BEA4CB8E1F7A207B0066BF44 /* Info.plist */,
 				B724CDA71F909ECA000FAA55 /* testMicropost.swift */,
@@ -272,11 +278,20 @@
 		BEA4CBB31F7B53410066BF44 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				BECD03CB1F972181006199CA /* OHHTTPStubs.framework */,
 				B724CD8E1F8C777B000FAA55 /* Kingfisher.framework */,
 				BEA4CBB41F7B53410066BF44 /* Alamofire.framework */,
 				BEA4CBB51F7B53410066BF44 /* SwiftyJSON.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		BECD03C81F972000006199CA /* StubFiles */ = {
+			isa = PBXGroup;
+			children = (
+				BECD03C91F972000006199CA /* successCreateMicropost.json */,
+			);
+			path = StubFiles;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -405,6 +420,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				BECD03CA1F972000006199CA /* successCreateMicropost.json in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -663,6 +679,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = spotterTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pepabo.spotterTests;
@@ -679,6 +699,10 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/Carthage/Build/iOS",
+				);
 				INFOPLIST_FILE = spotterTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.pepabo.spotterTests;

--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -11,7 +11,6 @@ import UIKit
 class ConfirmTweetViewController: UIViewController {
     
     var micropost = Micropost(userID: 0, content: "")
-    var pushedMicropost = Micropost(userID: 0, content: "")
     var emotionText = ""
     var music = Music()
     

--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -17,13 +17,7 @@ class ConfirmTweetViewController: UIViewController {
     @IBOutlet weak var tweetTextView: TweetTextView!
     
     @IBAction func emoteButton(_ sender: Any) {
-        let params: [String:Any] = [
-            "user_id": micropost.userID,
-            "micropost": ["content": micropost.content]
-            ]
-        micropost.postMicropost(params: params) { micropost in
-            dump(micropost)
-        }
+        micropost.post()
         dismiss(animated: true, completion: nil)
     }
     

--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -11,13 +11,14 @@ import UIKit
 class ConfirmTweetViewController: UIViewController {
     
     var micropost = Micropost(userID: 0, content: "")
+    var pushedMicropost = Micropost(userID: 0, content: "")
     var emotionText = ""
     var music = Music()
     
     @IBOutlet weak var tweetTextView: TweetTextView!
     
     @IBAction func emoteButton(_ sender: Any) {
-        micropost.post()
+        Micropost.pushMicropost(userID: micropost.userID, content: micropost.content) { micropost in }
         dismiss(animated: true, completion: nil)
     }
     

--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -17,13 +17,20 @@ class ConfirmTweetViewController: UIViewController {
     @IBOutlet weak var tweetTextView: TweetTextView!
     
     @IBAction func emoteButton(_ sender: Any) {
+        let params: [String:Any] = [
+            "user_id": micropost.userID,
+            "micropost": ["content": micropost.content]
+            ]
+        micropost.postMicropost(params: params) { micropost in
+            dump(micropost)
+        }
         dismiss(animated: true, completion: nil)
     }
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        
-        tweetTextView.text = "\(micropost.content)\n\(emotionText)\n\(music.name)(\(music.url))"
+        micropost.content += "\n\(emotionText)\n\(music.name)(\(music.url))"
+        tweetTextView.text = micropost.content
     }
 
     override func didReceiveMemoryWarning() {

--- a/spotter/Classes/Helpers/APIClient.swift
+++ b/spotter/Classes/Helpers/APIClient.swift
@@ -13,11 +13,11 @@ import SwiftyJSON
 class APIClient {
     static private let baseUrl = "http://piyorin.xyz"
     
-    static func request(endpoint: Endpoint, handler: @escaping (_ json: JSON) -> Void) {
+    static func request(endpoint: Endpoint, params: [String: Any]=[:], handler: @escaping (_ json: JSON) -> Void) {
         let method = endpoint.method()
         let url = fullURL(endpoint: endpoint)
         
-        Alamofire.request(url, method:method).validate(statusCode: 200...299).responseJSON { response in
+        Alamofire.request(url, method:method, parameters:params).validate(statusCode: 200...299).responseJSON { response in
             switch response.result {
             case .success(let value):
                 handler(JSON(value))

--- a/spotter/Classes/Helpers/APIClient.swift
+++ b/spotter/Classes/Helpers/APIClient.swift
@@ -35,11 +35,13 @@ class APIClient {
 enum Endpoint {
     case userProfile(Int)
     case userMicropost(Int)
+    case createMicropost
     
     func method() -> HTTPMethod {
         switch self {
         case .userProfile: return .get
         case .userMicropost: return .get
+        case .createMicropost: return .post
         }
     }
     
@@ -47,6 +49,7 @@ enum Endpoint {
         switch self {
         case .userProfile(let value): return "/api/users/\(String(value))/profile"
         case .userMicropost(let value): return "/api/users/\(String(value))/microposts"
+        case .createMicropost: return "/api/microposts/create"
         }
     }
 }

--- a/spotter/Classes/Models/Micropost.swift
+++ b/spotter/Classes/Models/Micropost.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftyJSON
 
 class Micropost {
+    var id = 0
     var userID: Int
     var content: String
     
@@ -30,14 +31,14 @@ class Micropost {
         }
     }
     
-    func post() {
+    static func pushMicropost(userID: Int, content: String, handler: @escaping ((Micropost) -> Void)) {
         let params: [String:Any] = [
-            "user_id": self.userID,
-            "micropost": ["content": self.content]
+            "user_id": userID,
+            "micropost": ["content": content]
         ]
         APIClient.request(endpoint: Endpoint.createMicropost, params: params) { json in
-            self.userID = json["micropost"]["user_id"].intValue
-            self.content = json["micropost"]["content"].stringValue
+            let pushedMicropost = Micropost(userID: json["micropost"]["user_id"].intValue, content: json["micropost"]["content"].stringValue)
+            return handler(pushedMicropost)
         }
     }
 }

--- a/spotter/Classes/Models/Micropost.swift
+++ b/spotter/Classes/Models/Micropost.swift
@@ -10,7 +10,6 @@ import Foundation
 import SwiftyJSON
 
 class Micropost {
-    var id = 0
     var userID: Int
     var content: String
     

--- a/spotter/Classes/Models/Micropost.swift
+++ b/spotter/Classes/Models/Micropost.swift
@@ -30,10 +30,14 @@ class Micropost {
         }
     }
     
-    func postMicropost(params: [String:Any], handler: @escaping ((Micropost) -> Void)) {
+    func post() {
+        let params: [String:Any] = [
+            "user_id": self.userID,
+            "micropost": ["content": self.content]
+        ]
         APIClient.request(endpoint: Endpoint.createMicropost, params: params) { json in
-            let micropost = Micropost(userID: json["micropost"]["user_id"].intValue, content: json["micropost"]["content"].stringValue)
-            return handler(micropost)
+            self.userID = json["micropost"]["user_id"].intValue
+            self.content = json["micropost"]["content"].stringValue
         }
     }
 }

--- a/spotter/Classes/Models/Micropost.swift
+++ b/spotter/Classes/Models/Micropost.swift
@@ -30,9 +30,10 @@ class Micropost {
         }
     }
     
-    static func postMicroposts(params: [String:Any], handler: @escaping ((Array<Micropost>) -> Void)) {
+    func postMicropost(params: [String:Any], handler: @escaping ((Micropost) -> Void)) {
         APIClient.request(endpoint: Endpoint.createMicropost, params: params) { json in
-            return handler(jsonToMicroposts(json))
+            let micropost = Micropost(userID: json["micropost"]["user_id"].intValue, content: json["micropost"]["content"].stringValue)
+            return handler(micropost)
         }
     }
 }

--- a/spotter/Classes/Models/Micropost.swift
+++ b/spotter/Classes/Models/Micropost.swift
@@ -29,4 +29,10 @@ class Micropost {
             return handler(jsonToMicroposts(json))
         }
     }
+    
+    static func postMicroposts(params: [String:Any], handler: @escaping ((Array<Micropost>) -> Void)) {
+        APIClient.request(endpoint: Endpoint.createMicropost, params: params) { json in
+            return handler(jsonToMicroposts(json))
+        }
+    }
 }

--- a/spotterTests/StubFiles/successCreateMicropost.json
+++ b/spotterTests/StubFiles/successCreateMicropost.json
@@ -1,0 +1,12 @@
+{
+    "micropost": {
+        "id": 320,
+        "content": "fugafuga",
+        "user_id": 1,
+        "created_at": "2017-10-17T15:36:54.000+09:00",
+        "updated_at": "2017-10-17T15:36:54.000+09:00",
+        "picture": {
+            "url": null
+        }
+    }
+}

--- a/spotterTests/testMicropost.swift
+++ b/spotterTests/testMicropost.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 @testable import spotter
+import OHHTTPStubs
 
 class testMicropost: XCTestCase {
     
@@ -25,6 +26,22 @@ class testMicropost: XCTestCase {
          Micropost.fetchMicroposts(userID: 1) { microposts in
             XCTAssertTrue(microposts.count > 1)
             fetchMicropostException?.fulfill()
+        }
+        self.waitForExpectations(timeout: 3, handler: nil)
+    }
+    
+    func testPushMicropost() {
+        stub(condition: isHost("piyorin.xyz") && isPath("/api/microposts/create")) { request in
+            let stubPath = OHPathForFile("successCreateMicropost.json", type(of: self))
+            return fixture(filePath: stubPath!, headers: ["Content-Type":"application/json"])
+        }
+        
+        let userID = 1
+        let content = "fugafuga"
+        let pushMicropostException: XCTestExpectation? =  self.expectation(description: "pushMicropost")
+        Micropost.pushMicropost(userID: userID, content: content) { micropost in
+            XCTAssertEqual(content, micropost.content)
+            pushMicropostException?.fulfill()
         }
         self.waitForExpectations(timeout: 3, handler: nil)
     }


### PR DESCRIPTION
### 何を解決するのか

- MicropostをPOSTすることができるようになる

### 詳細

- `APIClient.swift`
    - POSTのエンドポイントの追加
    - requestメソッドにparamsを追加し、POST時にパラメータを付加できるように変更
- `Micropost.swift`
    - POST処理を行うメソッドを追加
- `ConfirmTweetViewController.swift`
    - micropostインスタンスのデータを整理してPOSTする処理を記述
- `Cartfile`
    - OHHTTPStubsを導入
    - POST処理の単体テスト時にレスポンスをスタブするために利用

### レビューポイント

- POST処理

### レビュアー

@Fendo181 @Asuforce 

### 期限

なる速でお願いします！
