### PR TITLE
タイムラインの更新処理を追加

### DIFF
--- a/spotter/Classes/Controllers/TimeLineViewController.swift
+++ b/spotter/Classes/Controllers/TimeLineViewController.swift
@@ -26,6 +26,10 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         timelineView.rowHeight = UITableViewAutomaticDimension
         
         setTimelineViewElements()
+        
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(self.refreshTimeline(sender:)), for: .valueChanged)
+        timelineView.addSubview(refreshControl)
     }
     
     override func didReceiveMemoryWarning() {
@@ -66,6 +70,13 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         Micropost.fetchMicroposts(userID: userID) { microposts in
             self.microposts = microposts
             self.timelineView.reloadData()
+        }
+    }
+    
+    @objc func refreshTimeline(sender: UIRefreshControl) {
+        setTimelineViewElements()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            sender.endRefreshing()
         }
     }
 }


### PR DESCRIPTION
### 何を解決するのか

- タイムラインを更新することができるようになる

#### 動作
<img src="https://user-images.githubusercontent.com/28612605/31712087-0a9b34bc-b435-11e7-8ca5-c6c856150db9.gif" width="300">

### 詳細

- `TimeLineViewController.swift`
    - テーブルの更新処理を追加

#### テストについて
タイムラインの更新処理はタイムラインをGETし直して、テーブルを更新している。
この動作をUITestで行う場合GETする内容をスタブしなければならないが、UITestではスタブが動作せず、通常通りGETの動作を行ってしまう。
そのため、タイムラインの更新処理をUITestで書くのは難しいと判断したため、実機テストでカバーしたいと考えている:thinking:

### レビューポイント

- テーブルの更新処理
- テストについての判断

### レビュアー

@Fendo181 @Asuforce 

### 期限

なる速でお願いします！
