### PR TITLE
POST時にタイムラインを更新する処理の実装

### DIFF
--- a/spotter/Classes/Controllers/ConfirmTweetViewController.swift
+++ b/spotter/Classes/Controllers/ConfirmTweetViewController.swift
@@ -18,7 +18,11 @@ class ConfirmTweetViewController: UIViewController {
     
     @IBAction func emoteButton(_ sender: Any) {
         Micropost.pushMicropost(userID: micropost.userID, content: micropost.content) { micropost in }
-        dismiss(animated: true, completion: nil)
+        let timelineViewController = presentingViewController as! TimeLineViewController
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+            timelineViewController.setTimelineViewElements()
+            self.dismiss(animated: true, completion: nil)
+        }
     }
     
     override func viewDidLoad() {

--- a/spotter/Classes/Controllers/TimeLineViewController.swift
+++ b/spotter/Classes/Controllers/TimeLineViewController.swift
@@ -60,7 +60,7 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         }
     }
     
-    private func setTimelineViewElements() {
+    func setTimelineViewElements() {
         Users.fetchUsers(userID: userID) { users in
             self.userImageURL = users.imgURL
             self.usernameLabel.text = users.name

--- a/spotterUITests/tweetTransitionUITests.swift
+++ b/spotterUITests/tweetTransitionUITests.swift
@@ -46,6 +46,7 @@ class tweetTransitionUITest: XCTestCase {
         
         // ツイートしてタイムライン画面へ
         app.buttons["エモート"].tap()
+        sleep(2)
         XCTAssertFalse(app.textViews["confirmTweetTextField"].exists)
         XCTAssert(app.images["profileImage"].exists)
     }


### PR DESCRIPTION
### 何を解決するのか

- POST時にタイムラインを更新する処理を追加
- 投稿した内容がタイムラインで確認できるようになる

#### 動作
<img src="https://user-images.githubusercontent.com/28612605/31756944-ba12ec76-b4e1-11e7-9fc3-ae084e1c711d.gif" width="300">

### 詳細

- `ConfirmTweetViewController.swift`
    - エモートボタンを押したときにTimeLineViewControllerをインスタンス化してタイムラインのテーブルを更新
- テストは実機テストを行います


### レビューポイント

- タイムライン更新処理

### レビュアー

@Asuforce @Fendo181 

### 期限

なる速でお願いします！
