### PR TITLE
タイムラインのセルをタップしたときにURLを開く処理を実装

### DIFF
--- a/spotter.xcodeproj/project.pbxproj
+++ b/spotter.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		BECA063C1F87691200E9118A /* tweetTransitionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BECA063B1F87691200E9118A /* tweetTransitionUITests.swift */; };
 		BECD03CA1F972000006199CA /* successCreateMicropost.json in Resources */ = {isa = PBXBuildFile; fileRef = BECD03C91F972000006199CA /* successCreateMicropost.json */; };
 		BECD03CC1F972182006199CA /* OHHTTPStubs.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BECD03CB1F972181006199CA /* OHHTTPStubs.framework */; };
+		BEDB68901FA0353C0005B087 /* TimelineHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDB688F1FA0353C0005B087 /* TimelineHelper.swift */; };
+		BEDB68941FA039850005B087 /* testTimelineHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEDB68931FA039850005B087 /* testTimelineHelper.swift */; };
 		BEE4DEE51F9060E8004B2F94 /* Music.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE4DEE41F9060E8004B2F94 /* Music.swift */; };
 		BEEBAFC21F989BE5008FA413 /* SpotifyLogin.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BEEBAFC11F989BE5008FA413 /* SpotifyLogin.framework */; };
 /* End PBXBuildFile section */
@@ -109,6 +111,8 @@
 		BECA063B1F87691200E9118A /* tweetTransitionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = tweetTransitionUITests.swift; sourceTree = "<group>"; };
 		BECD03C91F972000006199CA /* successCreateMicropost.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = successCreateMicropost.json; sourceTree = "<group>"; };
 		BECD03CB1F972181006199CA /* OHHTTPStubs.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = OHHTTPStubs.framework; path = Carthage/Build/iOS/OHHTTPStubs.framework; sourceTree = "<group>"; };
+		BEDB688F1FA0353C0005B087 /* TimelineHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineHelper.swift; sourceTree = "<group>"; };
+		BEDB68931FA039850005B087 /* testTimelineHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = testTimelineHelper.swift; sourceTree = "<group>"; };
 		BEE4DEE41F9060E8004B2F94 /* Music.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Music.swift; sourceTree = "<group>"; };
 		BEEBAFC11F989BE5008FA413 /* SpotifyLogin.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SpotifyLogin.framework; path = Carthage/Build/iOS/SpotifyLogin.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -179,6 +183,7 @@
 		BEA4CB8B1F7A207B0066BF44 /* spotterTests */ = {
 			isa = PBXGroup;
 			children = (
+				BEDB68931FA039850005B087 /* testTimelineHelper.swift */,
 				BECD03C81F972000006199CA /* StubFiles */,
 				BEA4CB8C1F7A207B0066BF44 /* spotterTests.swift */,
 				BEA4CB8E1F7A207B0066BF44 /* Info.plist */,
@@ -229,6 +234,7 @@
 		BEA4CBA81F7A21BA0066BF44 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				BEDB688F1FA0353C0005B087 /* TimelineHelper.swift */,
 				B724CD941F8F48C0000FAA55 /* APIClient.swift */,
 			);
 			path = Helpers;
@@ -472,6 +478,7 @@
 				BEC8E1031F85FC6000AD1806 /* SelectMusicViewController.swift in Sources */,
 				BEA4CBB21F7A22EA0066BF44 /* ViewController.swift in Sources */,
 				B724CD981F8F5808000FAA55 /* Users.swift in Sources */,
+				BEDB68901FA0353C0005B087 /* TimelineHelper.swift in Sources */,
 				BE9AD4811F87505100B7E2AA /* ConfirmTweetViewController.swift in Sources */,
 				BEA4CBC21F7CC7E00066BF44 /* TweetViewController.swift in Sources */,
 				BEC8E1001F85FB9D00AD1806 /* MusicTableViewCell.swift in Sources */,
@@ -490,6 +497,7 @@
 			files = (
 				B724CDA81F909ECA000FAA55 /* testMicropost.swift in Sources */,
 				B724CDAA1F90A27B000FAA55 /* testUser.swift in Sources */,
+				BEDB68941FA039850005B087 /* testTimelineHelper.swift in Sources */,
 				BEA4CB8D1F7A207B0066BF44 /* spotterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/spotter/Classes/Controllers/TimeLineViewController.swift
+++ b/spotter/Classes/Controllers/TimeLineViewController.swift
@@ -49,7 +49,7 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         cell.faceImageView.kf.setImage(with: profile_url)
         
         let tweetText = microposts[indexPath.row].content
-        let urlTextArray = getMatchStrings(targetString: tweetText, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")
+        let urlTextArray = TimelineHelper.getMatchStrings(targetString: tweetText, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")
         if (urlTextArray.count == 0) {
             cell.tweetText.text = tweetText
             return cell
@@ -64,7 +64,7 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cell = timelineView.cellForRow(at: indexPath) as! TimelineTableViewCell
-        let urlTextArray = getMatchStrings(targetString: cell.tweetText.text!, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")
+        let urlTextArray = TimelineHelper.getMatchStrings(targetString: cell.tweetText.text!, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")
         if (urlTextArray.count != 0) {
             let url = URL(string: urlTextArray[0])
             if UIApplication.shared.canOpenURL(url!) {
@@ -100,25 +100,5 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             sender.endRefreshing()
         }
-    }
-    
-    // 正規表現にマッチした文字列を格納した配列を返す
-    func getMatchStrings(targetString: String, pattern: String) -> [String] {
-        var matchStrings:[String] = []
-        do {
-            let regex = try NSRegularExpression(pattern: pattern, options: [])
-            let targetStringRange = NSRange(location: 0, length: (targetString as NSString).length)
-            
-            let matches = regex.matches(in: targetString, options: [], range: targetStringRange)
-            
-            for match in matches {
-                let range = match.range(at: 0)
-                let result = (targetString as NSString).substring(with: range)
-                
-                matchStrings.append(result)
-            }
-            return matchStrings
-        } catch {}
-        return []
     }
 }

--- a/spotter/Classes/Controllers/TimeLineViewController.swift
+++ b/spotter/Classes/Controllers/TimeLineViewController.swift
@@ -47,7 +47,18 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         }
         
         cell.faceImageView.kf.setImage(with: profile_url)
-        cell.tweetText.text = microposts[indexPath.row].content
+//        cell.tweetText.text = microposts[indexPath.row].content
+        
+        cell.tweetText.isUserInteractionEnabled = true
+        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapGesture))
+        cell.tweetText.addGestureRecognizer(tapGestureRecognizer)
+        
+        let tweetText = microposts[indexPath.row].content
+        let urlText = getMatchStrings(targetString: tweetText, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")[0]
+        let urlRange = (tweetText as NSString).range(of: urlText)
+        let attributedString = NSMutableAttributedString(string: tweetText)
+        attributedString.addAttribute(NSAttributedStringKey.foregroundColor, value: UIColor.blue, range: urlRange)
+        cell.tweetText.attributedText = attributedString
         return cell
     }
     
@@ -78,5 +89,51 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             sender.endRefreshing()
         }
+    }
+    
+    @objc func tapGesture(gestureRecognizer: UITapGestureRecognizer) {
+        print("Url tapped")
+//        guard let text = helloLabel.text else { return }
+//        let touchPoint = gestureRecognizer.location(in: helloLabel)
+//        let textStorage = NSTextStorage(attributedString: NSAttributedString(string: linkText))
+//        let layoutManager = NSLayoutManager()
+//        textStorage.addLayoutManager(layoutManager)
+//        let textContainer = NSTextContainer(size: helloLabel.frame.size)
+//        layoutManager.addTextContainer(textContainer)
+//        textContainer.lineFragmentPadding = 0
+//        let toRange = (text as NSString).range(of: linkText)
+//        let glyphRange = layoutManager.glyphRange(forCharacterRange: toRange, actualCharacterRange: nil)
+//        let glyphRect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+//        if glyphRect.contains(touchPoint) {
+//            print("Tapped")
+//        }
+    }
+    
+    // 正規表現にマッチした文字列を格納した配列を返す
+    func getMatchStrings(targetString: String, pattern: String) -> [String] {
+        var matchStrings:[String] = []
+        
+        do {
+            
+            let regex = try NSRegularExpression(pattern: pattern, options: [])
+            let targetStringRange = NSRange(location: 0, length: (targetString as NSString).length)
+            
+            let matches = regex.matches(in: targetString, options: [], range: targetStringRange)
+            
+            for match in matches {
+                
+                // rangeAtIndexに0を渡すとマッチ全体が、1以降を渡すと括弧でグループにした部分マッチが返される
+                let range = match.range(at: 0)
+                let result = (targetString as NSString).substring(with: range)
+                
+                matchStrings.append(result)
+            }
+            
+            return matchStrings
+            
+        } catch {
+            print("error: getMatchStrings")
+        }
+        return []
     }
 }

--- a/spotter/Classes/Controllers/TimeLineViewController.swift
+++ b/spotter/Classes/Controllers/TimeLineViewController.swift
@@ -67,7 +67,7 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         let urlTextArray = getMatchStrings(targetString: cell.tweetText.text!, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")
         if (urlTextArray.count != 0) {
             let url = URL(string: urlTextArray[0])
-            if UIApplication.shared.canOpenURL(url!){
+            if UIApplication.shared.canOpenURL(url!) {
                 UIApplication.shared.open(url!)
             }
         }
@@ -118,9 +118,7 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
                 matchStrings.append(result)
             }
             return matchStrings
-        } catch {
-            print("error: getMatchStrings")
-        }
+        } catch {}
         return []
     }
 }

--- a/spotter/Classes/Controllers/TimeLineViewController.swift
+++ b/spotter/Classes/Controllers/TimeLineViewController.swift
@@ -47,7 +47,6 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         }
         
         cell.faceImageView.kf.setImage(with: profile_url)
-//        cell.tweetText.text = microposts[indexPath.row].content
         
         let tweetText = microposts[indexPath.row].content
         let urlText = getMatchStrings(targetString: tweetText, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")[0]
@@ -55,6 +54,7 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         let attributedString = NSMutableAttributedString(string: tweetText)
         attributedString.addAttribute(NSAttributedStringKey.foregroundColor, value: UIColor.blue, range: urlRange)
         cell.tweetText.attributedText = attributedString
+        
         return cell
     }
     
@@ -99,25 +99,19 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
     // 正規表現にマッチした文字列を格納した配列を返す
     func getMatchStrings(targetString: String, pattern: String) -> [String] {
         var matchStrings:[String] = []
-        
         do {
-            
             let regex = try NSRegularExpression(pattern: pattern, options: [])
             let targetStringRange = NSRange(location: 0, length: (targetString as NSString).length)
             
             let matches = regex.matches(in: targetString, options: [], range: targetStringRange)
             
             for match in matches {
-                
-                // rangeAtIndexに0を渡すとマッチ全体が、1以降を渡すと括弧でグループにした部分マッチが返される
                 let range = match.range(at: 0)
                 let result = (targetString as NSString).substring(with: range)
                 
                 matchStrings.append(result)
             }
-            
             return matchStrings
-            
         } catch {
             print("error: getMatchStrings")
         }

--- a/spotter/Classes/Controllers/TimeLineViewController.swift
+++ b/spotter/Classes/Controllers/TimeLineViewController.swift
@@ -49,10 +49,6 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         cell.faceImageView.kf.setImage(with: profile_url)
 //        cell.tweetText.text = microposts[indexPath.row].content
         
-        cell.tweetText.isUserInteractionEnabled = true
-        let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(tapGesture))
-        cell.tweetText.addGestureRecognizer(tapGestureRecognizer)
-        
         let tweetText = microposts[indexPath.row].content
         let urlText = getMatchStrings(targetString: tweetText, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")[0]
         let urlRange = (tweetText as NSString).range(of: urlText)
@@ -60,6 +56,15 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         attributedString.addAttribute(NSAttributedStringKey.foregroundColor, value: UIColor.blue, range: urlRange)
         cell.tweetText.attributedText = attributedString
         return cell
+    }
+    
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let cell = timelineView.cellForRow(at: indexPath) as! TimelineTableViewCell
+        let urlText = getMatchStrings(targetString: cell.tweetText.text!, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")[0]
+        let url = URL(string: urlText)
+        if UIApplication.shared.canOpenURL(url!){
+            UIApplication.shared.open(url!)
+        }
     }
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
@@ -89,24 +94,6 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
             sender.endRefreshing()
         }
-    }
-    
-    @objc func tapGesture(gestureRecognizer: UITapGestureRecognizer) {
-        print("Url tapped")
-//        guard let text = helloLabel.text else { return }
-//        let touchPoint = gestureRecognizer.location(in: helloLabel)
-//        let textStorage = NSTextStorage(attributedString: NSAttributedString(string: linkText))
-//        let layoutManager = NSLayoutManager()
-//        textStorage.addLayoutManager(layoutManager)
-//        let textContainer = NSTextContainer(size: helloLabel.frame.size)
-//        layoutManager.addTextContainer(textContainer)
-//        textContainer.lineFragmentPadding = 0
-//        let toRange = (text as NSString).range(of: linkText)
-//        let glyphRange = layoutManager.glyphRange(forCharacterRange: toRange, actualCharacterRange: nil)
-//        let glyphRect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
-//        if glyphRect.contains(touchPoint) {
-//            print("Tapped")
-//        }
     }
     
     // 正規表現にマッチした文字列を格納した配列を返す

--- a/spotter/Classes/Controllers/TimeLineViewController.swift
+++ b/spotter/Classes/Controllers/TimeLineViewController.swift
@@ -49,8 +49,12 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
         cell.faceImageView.kf.setImage(with: profile_url)
         
         let tweetText = microposts[indexPath.row].content
-        let urlText = getMatchStrings(targetString: tweetText, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")[0]
-        let urlRange = (tweetText as NSString).range(of: urlText)
+        let urlTextArray = getMatchStrings(targetString: tweetText, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")
+        if (urlTextArray.count == 0) {
+            cell.tweetText.text = tweetText
+            return cell
+        }
+        let urlRange = (tweetText as NSString).range(of: urlTextArray[0])
         let attributedString = NSMutableAttributedString(string: tweetText)
         attributedString.addAttribute(NSAttributedStringKey.foregroundColor, value: UIColor.blue, range: urlRange)
         cell.tweetText.attributedText = attributedString
@@ -60,10 +64,12 @@ class TimeLineViewController: UIViewController, UITableViewDelegate, UITableView
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         let cell = timelineView.cellForRow(at: indexPath) as! TimelineTableViewCell
-        let urlText = getMatchStrings(targetString: cell.tweetText.text!, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")[0]
-        let url = URL(string: urlText)
-        if UIApplication.shared.canOpenURL(url!){
-            UIApplication.shared.open(url!)
+        let urlTextArray = getMatchStrings(targetString: cell.tweetText.text!, pattern: "(http://|https://){1}[\\w\\.\\-/:]+")
+        if (urlTextArray.count != 0) {
+            let url = URL(string: urlTextArray[0])
+            if UIApplication.shared.canOpenURL(url!){
+                UIApplication.shared.open(url!)
+            }
         }
     }
     

--- a/spotter/Classes/Helpers/TimelineHelper.swift
+++ b/spotter/Classes/Helpers/TimelineHelper.swift
@@ -1,0 +1,31 @@
+//
+//  TimelineHelper.swift
+//  spotter
+//
+//  Created by komei.nomura on 2017/10/25.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import Foundation
+
+class TimelineHelper {
+    // 正規表現にマッチした文字列を格納した配列を返す
+    static func getMatchStrings(targetString: String, pattern: String) -> [String] {
+        var matchStrings:[String] = []
+        do {
+            let regex = try NSRegularExpression(pattern: pattern, options: [])
+            let targetStringRange = NSRange(location: 0, length: (targetString as NSString).length)
+            
+            let matches = regex.matches(in: targetString, options: [], range: targetStringRange)
+            
+            for match in matches {
+                let range = match.range(at: 0)
+                let result = (targetString as NSString).substring(with: range)
+                
+                matchStrings.append(result)
+            }
+            return matchStrings
+        } catch {}
+        return []
+    }
+}

--- a/spotterTests/testTimelineHelper.swift
+++ b/spotterTests/testTimelineHelper.swift
@@ -1,0 +1,35 @@
+//
+//  testTimelineHelper.swift
+//  spotterTests
+//
+//  Created by komei.nomura on 2017/10/25.
+//  Copyright © 2017年 GMO Pepabo. All rights reserved.
+//
+
+import XCTest
+@testable import spotter
+
+class testTimelineHelper: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testGetMatchStrings() {
+        let textIncludeUrl = "hogehoge\nhttps://example.com"
+        let text = "hogehoge"
+        let regularExpressionUrl = "(http://|https://){1}[\\w\\.\\-/:]+"
+        
+        var urls = TimelineHelper.getMatchStrings(targetString: textIncludeUrl, pattern: regularExpressionUrl)
+        
+        XCTAssert(urls.count > 0)
+        
+        urls = TimelineHelper.getMatchStrings(targetString: text, pattern: regularExpressionUrl)
+        
+        XCTAssert(urls.count == 0)
+    }
+}


### PR DESCRIPTION
### 何を解決するのか

- タイムラインのセルをタップしたときに対応するURLをタップする処理を実装
    - セルにURLが含まれていないときは何もしない
- 楽曲のURLに飛んで聞けるようになる

### 動作

<img src="https://user-images.githubusercontent.com/28612605/31976673-c81d3614-b973-11e7-87ce-99e8e3ff68a3.gif" width="300">

### 詳細

- `TimeLineViewController.swift`
    - URLの部分の色を青にする処理を追加
    - セルをタップしたときにURLを開く処理を実装
    - `getMatchStrings`
        - 正規表現にマッチした文字列の配列を返す処理

### レビューポイント

- URLを開く処理

### レビュアー

@Fendo181 @Asuforce 

### 期限

なる速でお願いします！
